### PR TITLE
리액트 컴포넌트의 반환 타입 수정

### DIFF
--- a/client/src/components/Logo/index.tsx
+++ b/client/src/components/Logo/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LogoPropType } from './types';
 import StyledLogo from './style';
 
-function Logo({ height }: LogoPropType): React.ReactElement {
+function Logo({ height }: LogoPropType): JSX.Element {
   return (
     <StyledLogo height={height}>
       <svg

--- a/client/src/components/common/buttons/OAuthLoginButton/index.tsx
+++ b/client/src/components/common/buttons/OAuthLoginButton/index.tsx
@@ -5,7 +5,7 @@ type PropsType = {
   provider: 'google' | 'naver' | 'kakao';
 };
 
-function OAuthLoginButton({ provider }: PropsType): React.ReactElement {
+function OAuthLoginButton({ provider }: PropsType): JSX.Element {
   const { Button, text } = LoginButtonResourceFactory.getButtonResource(provider);
   const clickHandler = () => {
     const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;


### PR DESCRIPTION
### Issue Number

Close #

### 변경사항

- 컴포넌트 구현시 반환 타입을 ReactElement로 사용했었는데 하나로 통일하기 위해 JSX.Element 타입으로 수정했습니다.
- JSX.Element는 ReactElement의 하위 개념에 속한다고 합니다.

**참고자료**
https://simsimjae.tistory.com/426


### 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
