### PR TITLE
Server의 lint-staged 가 동작하지 않던 이슈 해결

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
       "prettier --write",
       "git add"
     ],
-    "*.{ts}": [
+    "*.{ts,tsx}": [
       "prettier --write",
       "eslint --fix",
       "git add"


### PR DESCRIPTION
### Issue Number

Close #43 

### 변경사항

- lint-staged에서 탐지하는 파일 확장자 타입을 *.{ts} -> *.{ts,tsx}로 변경함.
- yarn.lock 파일 충돌이 자주 생기는 것 같아 버전관리에서 제외해보기로 얘기를 했었는데, 자료를 찾아보니 yarn.lock은 버전관리에 포함을 시키는 것이 맞다고 해서 일단은 보류했습니다.

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
