### PR TITLE
가계부 단일 내역 컴포넌트 구현

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -7,6 +7,9 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/preset-create-react-app',
   ],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
   webpackFinal: async (config) => {
     [].push.apply(config.resolve.plugins, [
       new TsconfigPathsPlugin({ extensions: config.resolve.extensions }),

--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,9 +1,5 @@
 import { Reset } from 'styled-reset';
-import GlobalStyled from '@/GlobalStyled';
-
-export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
-};
+import GlobalStyled from '../src/GlobalStyled';
 
 export const decorators = [
   (Story) => (
@@ -14,3 +10,7 @@ export const decorators = [
     </>
   ),
 ];
+
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+};

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,9 @@
       "last 1 safari version"
     ]
   },
+  "resolutions": {
+    "react-scripts/eslint-webpack-plugin": "2.3.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.12.7",
     "@storybook/addon-actions": "^6.1.2",

--- a/client/src/components/transaction/ListItem/index.stories.tsx
+++ b/client/src/components/transaction/ListItem/index.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import TransactionListItem from '.';
+
+export default {
+  title: 'components/transaction/ListItem',
+  component: TransactionListItem,
+};
+
+const mockTransactions = [
+  {
+    tid: 80,
+    amount: 50000000000000,
+    tradeAt: '2020-10-01',
+    description:
+      'user1의 가계부내역 80입니다. 이 가계부는 영국에서부터 시작되어 다음 사람에게 보내지 않을 시 3대가 대박나고 당신의 미래는 화창할 것입니다.',
+    isIncome: true,
+    uid: 1,
+    cid: 1,
+    pid: 3,
+    payment: {
+      pid: 3,
+      name: '농협은행 체크카드',
+      uid: 1,
+    },
+    category: {
+      cid: 1,
+      name: '월급',
+      isIncome: true,
+      uid: 1,
+    },
+  },
+  {
+    tid: 82,
+    amount: 7000,
+    tradeAt: '2020-10-01',
+    description: 'user1의 가계부내역 82',
+    isIncome: false,
+    uid: 1,
+    cid: 2,
+    pid: 3,
+    payment: {
+      pid: 3,
+      name: '농협은행',
+      uid: 1,
+    },
+    category: {
+      cid: 2,
+      name: '식비',
+      isIncome: false,
+      uid: 1,
+    },
+  },
+  {
+    tid: 83,
+    amount: 3500,
+    tradeAt: '2020-10-01',
+    description: 'user1의 가계부내역 83',
+    isIncome: false,
+    uid: 1,
+    cid: 3,
+    pid: 3,
+    payment: {
+      pid: 3,
+      name: '농협은행',
+      uid: 1,
+    },
+    category: {
+      cid: 3,
+      name: '교통비',
+      isIncome: false,
+      uid: 1,
+    },
+  },
+  {
+    tid: 84,
+    amount: 4000,
+    tradeAt: '2020-10-01',
+    description: 'user1의 가계부내역 84',
+    isIncome: false,
+    uid: 1,
+    cid: 2,
+    pid: 3,
+    payment: {
+      pid: 3,
+      name: '농협은행',
+      uid: 1,
+    },
+    category: {
+      cid: 2,
+      name: '식비',
+      isIncome: false,
+      uid: 1,
+    },
+  },
+];
+
+export const MonoListItem = (): JSX.Element => (
+  <TransactionListItem transaction={mockTransactions[0]} />
+);
+
+export const MultipleListItem = (): JSX.Element => (
+  <>
+    {mockTransactions.map((mockTransaction) => (
+      <TransactionListItem transaction={mockTransaction} />
+    ))}
+  </>
+);

--- a/client/src/components/transaction/ListItem/index.tsx
+++ b/client/src/components/transaction/ListItem/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import AmountText from '@/components/transaction/AmountText';
+import { TransactionListItemPropType } from './types';
+import S from './styles';
+
+const TransactionListItem = ({ transaction }: TransactionListItemPropType): JSX.Element => {
+  return (
+    <S.ListItem>
+      <S.ListItemContentsRow>
+        <S.ListItemDescription>{transaction.description}</S.ListItemDescription>
+      </S.ListItemContentsRow>
+      <S.ListItemContentsRow>
+        <S.ListItemPaymentInfo>
+          {transaction.category.name} | {transaction.payment.name}
+        </S.ListItemPaymentInfo>
+        <S.ListItemAmount>
+          <AmountText isIncome={transaction.isIncome} amount={transaction.amount} size="sm" />
+        </S.ListItemAmount>
+      </S.ListItemContentsRow>
+    </S.ListItem>
+  );
+};
+
+export default TransactionListItem;

--- a/client/src/components/transaction/ListItem/styles.ts
+++ b/client/src/components/transaction/ListItem/styles.ts
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+const ListItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  width: 100%;
+  align-items: center;
+  border-radius: 0.3rem;
+  box-shadow: 1px 2px 4px 1px rgba(0, 0, 0, 0.2);
+
+  font-size: 0.8rem;
+  padding: 0.8rem 1rem;
+
+  & + & {
+    margin-top: 0.7rem;
+  }
+`;
+
+const ListItemContentsRow = styled.div`
+  display: flex;
+  width: 100%;
+  & + & {
+    margin-top: 1rem;
+  }
+`;
+
+const ListItemDescription = styled.div`
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ListItemPaymentInfo = styled.div`
+  flex: 0 0 auto;
+  color: rgba(0, 0, 0, 0.6);
+`;
+
+const ListItemAmount = styled.div`
+  flex: 1 1 auto;
+  text-align: right;
+`;
+
+export default {
+  ListItem,
+  ListItemContentsRow,
+  ListItemDescription,
+  ListItemPaymentInfo,
+  ListItemAmount,
+};

--- a/client/src/components/transaction/ListItem/types.ts
+++ b/client/src/components/transaction/ListItem/types.ts
@@ -1,0 +1,25 @@
+export type Transaction = {
+  tid: number;
+  amount: number;
+  tradeAt: string;
+  description: string;
+  isIncome: boolean;
+  uid: number;
+  cid: number;
+  pid: number;
+  payment: {
+    pid: number;
+    name: string;
+    uid: number;
+  };
+  category: {
+    cid: number;
+    name: string;
+    isIncome: boolean;
+    uid: number;
+  };
+};
+
+export type TransactionListItemPropType = {
+  transaction: Transaction;
+};


### PR DESCRIPTION
### Issue Number

Close #79 

### 새로운 기능

- 가계부 리스트를 렌더링할때 단일 내역을 렌더링하는 컴포넌트를 구현함.

**단일**
![스크린샷 2020-12-01 오후 1 50 45](https://user-images.githubusercontent.com/17294694/100699711-0d5f3900-33df-11eb-9302-971d9d872d54.png)

**리스트일때**
![스크린샷 2020-12-01 오후 1 50 36](https://user-images.githubusercontent.com/17294694/100699713-0f28fc80-33df-11eb-9a05-eea64b871227.png)


### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
