### PR TITLE
월 가계부 내역을 불러오는 API 호출 모듈을 구현 및 리팩토링

### DIFF
--- a/client/src/commons/types/axios.ts
+++ b/client/src/commons/types/axios.ts
@@ -1,0 +1,14 @@
+// Code Reference: https://github.com/axios/axios/issues/1510
+import 'axios';
+
+declare module 'axios' {
+  export interface AxiosInstance {
+    request<T = any>(config: AxiosRequestConfig): Promise<T>;
+    get<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+    delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+    head<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
+    post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
+    put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
+    patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>;
+  }
+}

--- a/client/src/commons/types/transaction.ts
+++ b/client/src/commons/types/transaction.ts
@@ -1,0 +1,32 @@
+export type TransactionModel = {
+  tid: number;
+  amount: number;
+  tradeAt: string;
+  description: string;
+  isIncome: boolean;
+  uid: number;
+  cid: number;
+  pid: number;
+  payment: {
+    pid: number;
+    name: string;
+    uid: number;
+  };
+  category: {
+    cid: number;
+    name: string;
+    isIncome: boolean;
+    uid: number;
+  };
+};
+
+export type MonthTransactionsResponse = {
+  totalIn: number;
+  totalOut: number;
+  mostOutDateDetail: {
+    amount: number;
+    date: number;
+  };
+  aggregationByDate: [number, { totalIn: number; totalOut: number }][];
+  transactionDetailsByDate: [number, TransactionModel[]][];
+};

--- a/client/src/components/common/buttons/OAuthLoginButton/index.tsx
+++ b/client/src/components/common/buttons/OAuthLoginButton/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import endpoints from '@/libs/endpoints';
 import LoginButtonResourceFactory from './buttonResourceFactory';
 
 type PropsType = {
@@ -8,8 +9,7 @@ type PropsType = {
 function OAuthLoginButton({ provider }: PropsType): JSX.Element {
   const { Button, text } = LoginButtonResourceFactory.getButtonResource(provider);
   const clickHandler = () => {
-    const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
-    window.location.href = `${apiBaseUrl}/api/auth/${provider}`;
+    window.location.href = `${endpoints.API_BASE_URL}${endpoints.AUTH_API}/${provider}`;
   };
 
   return <Button onClick={clickHandler}>{text}</Button>;

--- a/client/src/components/transaction/AmountText/index.stories.tsx
+++ b/client/src/components/transaction/AmountText/index.stories.tsx
@@ -13,3 +13,5 @@ export const ExpenditureText = (): JSX.Element => <AmountText isIncome={false} a
 export const LargeSizeText = (): JSX.Element => <AmountText isIncome size="lg" amount={10000} />;
 
 export const SmallSizeText = (): JSX.Element => <AmountText isIncome size="sm" amount={10000} />;
+
+export const XSSizeText = (): JSX.Element => <AmountText isIncome size="xs" amount={10000} />;

--- a/client/src/components/transaction/AmountText/styles.ts
+++ b/client/src/components/transaction/AmountText/styles.ts
@@ -10,6 +10,9 @@ const StyledAmountText = styled.span<StyledAmountTextProps>`
     if (props.size === 'sm') {
       return '0.8rem';
     }
+    if (props.size === 'xs') {
+      return '0.5rem';
+    }
     return '1rem';
   }};
   font-weight: 600;

--- a/client/src/components/transaction/AmountText/types.ts
+++ b/client/src/components/transaction/AmountText/types.ts
@@ -1,7 +1,7 @@
 export type AmountTextProps = {
   isIncome: boolean;
   amount: number;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 };
 
 export type StyledAmountTextProps = {

--- a/client/src/libs/api/category.ts
+++ b/client/src/libs/api/category.ts
@@ -1,13 +1,11 @@
+import axios from '@/libs/axios';
+import endpoints from '@/libs/endpoints';
 import { CategoryModel } from '@commons/types/category';
-import Axios from 'axios';
 
 const categoryAPI = {
   getCategory: async (): Promise<CategoryModel[]> => {
-    const response = await Axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/categories`, {
-      withCredentials: true,
-    });
-
-    return response.data;
+    const categories = await axios.get<CategoryModel[]>(endpoints.CATEGORY_API);
+    return categories;
   },
 };
 

--- a/client/src/libs/api/payment.ts
+++ b/client/src/libs/api/payment.ts
@@ -1,13 +1,11 @@
+import axios from '@/libs/axios';
+import endpoints from '@/libs/endpoints';
 import { PaymentModel } from '@commons/types/payment';
-import Axios from 'axios';
 
 const paymentAPI = {
   getPayment: async (): Promise<PaymentModel[]> => {
-    const response = await Axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/payment-methods`, {
-      withCredentials: true,
-    });
-
-    return response.data;
+    const payments = await axios.get<PaymentModel[]>(endpoints.PAYMENT_METHOD_API);
+    return payments;
   },
 };
 

--- a/client/src/libs/api/transaction.ts
+++ b/client/src/libs/api/transaction.ts
@@ -1,0 +1,20 @@
+import axios from '@/libs/axios';
+import endpoints from '@/libs/endpoints';
+import { MonthTransactionsResponse } from '@/commons/types/transaction';
+
+const transactionAPI = {
+  getMonthTransactions: async ({
+    year,
+    month,
+  }: {
+    year: number;
+    month: number;
+  }): Promise<MonthTransactionsResponse> => {
+    const monthlyTransactionDetails = await axios.get<MonthTransactionsResponse>(
+      `${endpoints.TRANSACTION_API}?year=${year}&month=${month}`,
+    );
+    return monthlyTransactionDetails;
+  },
+};
+
+export default transactionAPI;

--- a/client/src/libs/axios.ts
+++ b/client/src/libs/axios.ts
@@ -3,10 +3,11 @@ import endpoints from './endpoints';
 
 const instance = axios.create({
   baseURL: endpoints.API_BASE_URL,
+  withCredentials: true,
 });
 
 instance.interceptors.response.use(
-  (response) => response.data,
+  (response) => Promise.resolve(response.data),
   (error) => Promise.reject(error),
 );
 

--- a/client/src/libs/endpoints.ts
+++ b/client/src/libs/endpoints.ts
@@ -1,5 +1,5 @@
 export default {
-  API_BASE_URL: process.env.REACT_APP_API_BASE_URL || 'http;//localhost:4000',
+  API_BASE_URL: process.env.REACT_APP_API_BASE_URL || 'http://localhost:4000',
   TRANSACTION_API: '/api/transactions',
   PAYMENT_METHOD_API: '/api/payment-methods',
   CATEGORY_API: '/api/categories',

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "typeRoots": ["./node_modules/@types", "./src/commons/types"],
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -21,8 +18,5 @@
     "allowJs": true
   },
   "extends": "./tsconfig.paths.json",
-  "include": [
-    "src",
-    "config-overrides.js"
-  ]
+  "include": ["src", "config-overrides.js"]
 }


### PR DESCRIPTION
### Issue Number

Close #83 

### 변경사항

- Category, Payment API 호출 모듈에서 프로젝트에서 새로 생성한 axios 인스턴스를 사용하도록 수정했습니다.
- OAuthLoginButton 컴포넌트에서에서 REACT_APP_API_BASE_URL 환경변수를 사용하는 방식 -> endpoints 상수 사용으로 변경했습니다.
- endpoints.API_BASE_URL 오타를 수정했습니다.
- 금액을 표시하는 text 컴포넌트에서 sm 사이즈가 달력용으로 사용하기에 크기가 커서 한단계 더 작은 xs 사이즈를 추가했습니다.

### 새로운 기능

- axios의 interceptor를 이용해 response의 data를 반환하도록 설정된 것에 맞춰서 기존 응답 타입을 재정의했습니다.
- 월 가계부 내역을 불러오는 API 호출 모듈을 구현했습니다.
- 도메인간 쿠키 전송을 위한 withCredentials 옵션을 default로 설정되도록 추가했습니다.

### 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
