### PR TITLE
고정 지출 컨테이너, 상세 페이지 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.1",
     "react-app-rewire-alias": "^0.1.8",
     "react-dom": "^17.0.1",
+    "react-icons": "^4.1.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import DashBoardPage from '@/views/DashBoardPage';
 import LoginPage from '@/views/LoginPage';
 import CalendarPage from '@/views/Calendar';
+import DetailedFixedExpenditurePage from '@/views/DetailedFixedExpenditurePage';
 import GlobalStyled from './GlobalStyled';
 
 const Box = styled.div`
@@ -24,6 +25,7 @@ function App(): JSX.Element {
           <Route path="/" component={LoginPage} exact />
           <Route path="/dashboard" component={DashBoardPage} />
           <Route path="/calendar" component={CalendarPage} />
+          <Route path="/detailed-fixed-expenditure" component={DetailedFixedExpenditurePage} />
           <Redirect from="*" to="/dashboard" />
         </Switch>
       </Box>

--- a/client/src/components/common/layouts/MainLayout/index.tsx
+++ b/client/src/components/common/layouts/MainLayout/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Header from '@/components/common/layouts/Header';
+import Authorization from '@container/Authorization';
 import StyledMainContainer from './styles';
 import { MainLayoutPropsType } from './types';
 
 const MainLayout = ({ children }: MainLayoutPropsType): JSX.Element => {
   return (
     <>
+      <Authorization />
       <Header />
       <StyledMainContainer>{children}</StyledMainContainer>
     </>

--- a/client/src/components/fixedExpenditure/Item/index.tsx
+++ b/client/src/components/fixedExpenditure/Item/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import numberUtils from '@libs/numberUtils';
+import { FixedExpenditureItemPropType } from './types';
+import * as S from './styles';
+
+const FixedExpenditureItem = ({ fixedItem }: FixedExpenditureItemPropType): JSX.Element => {
+  return (
+    <S.Box>
+      <S.TitleBox>
+        <S.Description>{fixedItem.description}</S.Description>
+        <S.Amount>약 {numberUtils.numberWithCommas(fixedItem.amount)} 원</S.Amount>
+      </S.TitleBox>
+      <S.Date>{fixedItem.tradeAt.toString().substring(8)}일</S.Date>
+    </S.Box>
+  );
+};
+
+export default FixedExpenditureItem;

--- a/client/src/components/fixedExpenditure/Item/styles.ts
+++ b/client/src/components/fixedExpenditure/Item/styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Box = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const TitleBox = styled.div``;
+
+export const Description = styled.p`
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+`;
+
+export const Amount = styled.p`
+  font-weight: 600;
+  color: #a4a4a4;
+`;
+
+export const Date = styled.p`
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #a4a4a4;
+`;

--- a/client/src/components/fixedExpenditure/Item/types.ts
+++ b/client/src/components/fixedExpenditure/Item/types.ts
@@ -1,0 +1,5 @@
+import { FixedExpenditure } from '@/commons/types/fixedExpenditure';
+
+export type FixedExpenditureItemPropType = {
+  fixedItem: FixedExpenditure;
+};

--- a/client/src/container/DashboardDetails/index.tsx
+++ b/client/src/container/DashboardDetails/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@modules/index';
 import TransactionListItem from '@/components/transaction/ListItem';
 import AmountText from '@/components/transaction/AmountText';
+import FixedExpenditure from '@container/FixedExpenditure';
 import * as S from './styles';
 
 const RECENT_TRANSACTION_LIMIT = 3;
@@ -33,6 +34,7 @@ const DashboardDetailsContainer = (): JSX.Element => {
           </S.RecentTransactionBoxItem>
         ))}
       </S.RecentTransactionBox>
+      <FixedExpenditure />
     </>
   );
 };

--- a/client/src/container/DetailedFixedExpenditure/index.tsx
+++ b/client/src/container/DetailedFixedExpenditure/index.tsx
@@ -4,12 +4,11 @@ import { getFixedExpenditureThunk } from '@modules/fixedExpenditure';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/modules';
 import dateUtils from '@libs/dateUtils';
-import { Link } from 'react-router-dom';
-import { GoCalendar } from 'react-icons/go';
 import numberUtils from '@libs/numberUtils';
+import FixedExpenditureItem from '@components/fixedExpenditure/Item';
 import * as S from './styles';
 
-const FixedExpenditure = (): JSX.Element => {
+const DetailedFixedExpenditure = (): JSX.Element => {
   const { datePicker, fixedExpenditure } = useSelector((state: RootState) => state);
   const dispatch = useDispatch();
 
@@ -36,23 +35,22 @@ const FixedExpenditure = (): JSX.Element => {
   return (
     <>
       <S.Box>
-        <S.HeaderBox>
-          <S.HeaderTitle>
-            <p>예정된 고정지출이</p>
-            <p>{fixedExpenditure.fixedExpenditure.data?.length}개 있어요</p>
-          </S.HeaderTitle>
-          <Link to="/detailed-fixed-expenditure">자세히 보기</Link>
-        </S.HeaderBox>
-        <S.SumBox>
-          <GoCalendar />
-          <S.TextBox>
-            <S.SumTitle>예정된 고정 지출</S.SumTitle>
-            <S.Amount>{getSumFixedExpenditure()}원</S.Amount>
-          </S.TextBox>
-        </S.SumBox>
+        <S.Title>고정적인 지출</S.Title>
+        <S.Amount>총 {getSumFixedExpenditure()} 원</S.Amount>
+      </S.Box>
+      <S.Box>
+        {fixedExpenditure.fixedExpenditure.data ? (
+          fixedExpenditure.fixedExpenditure.data.map((fixedItem) => (
+            <S.ItemBox key={fixedItem.fid}>
+              <FixedExpenditureItem fixedItem={fixedItem} />
+            </S.ItemBox>
+          ))
+        ) : (
+          <div />
+        )}
       </S.Box>
     </>
   );
 };
 
-export default FixedExpenditure;
+export default DetailedFixedExpenditure;

--- a/client/src/container/DetailedFixedExpenditure/styles.ts
+++ b/client/src/container/DetailedFixedExpenditure/styles.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+const DefaultStyle = styled.div`
+  border-radius: 0.3rem;
+  box-shadow: 1px 2px 4px 1px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+`;
+
+export const Box = styled(DefaultStyle)`
+  max-width: 100%;
+  width: 100%;
+  margin-top: 1rem;
+`;
+
+export const Title = styled.p`
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+`;
+
+export const Amount = styled.p`
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #a4a4a4;
+`;
+
+export const ItemBox = styled.div`
+  padding: 0.7rem 0;
+  & + & {
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+  }
+`;

--- a/client/src/container/FixedExpenditure/index.tsx
+++ b/client/src/container/FixedExpenditure/index.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, useEffect } from 'react';
+/* eslint-disable no-restricted-syntax */
+import React, { useCallback, useMemo, useEffect } from 'react';
 import { getFixedExpenditureThunk } from '@modules/fixedExpenditure';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/modules';
 import dateUtils from '@libs/dateUtils';
+import { Link } from 'react-router-dom';
+import { GoCalendar } from 'react-icons/go';
+import * as S from './styles';
 
 const FixedExpenditure = (): JSX.Element => {
-  const { datePicker } = useSelector((state: RootState) => state);
+  const { datePicker, fixedExpenditure } = useSelector((state: RootState) => state);
   const dispatch = useDispatch();
 
   const getFixedExpenditure = useCallback(() => {
@@ -13,10 +17,41 @@ const FixedExpenditure = (): JSX.Element => {
     dispatch(getFixedExpenditureThunk(startDate, endDate));
   }, [dispatch, datePicker]);
 
+  const getSumFixedExpenditure = useCallback(() => {
+    const { data } = fixedExpenditure.fixedExpenditure;
+    if (data) {
+      let sum = 0;
+      for (const value of data) {
+        sum += value.amount;
+      }
+      return sum;
+    }
+    return 0;
+  }, [fixedExpenditure]);
+
   useEffect(() => {
     getFixedExpenditure();
   }, [dispatch, datePicker]);
-  return <></>;
+  return (
+    <>
+      <S.Box>
+        <S.HeaderBox>
+          <S.HeaderTitle>
+            <p>예정된 고정지출이</p>
+            <p>{fixedExpenditure.fixedExpenditure.data?.length}개 있어요</p>
+          </S.HeaderTitle>
+          <Link to="/detail-fixed-expenditure">자세히 보기</Link>
+        </S.HeaderBox>
+        <S.SumBox>
+          <GoCalendar />
+          <S.TextBox>
+            <S.SumTitle>예정된 고정 지출</S.SumTitle>
+            <S.Amount>{getSumFixedExpenditure()}원</S.Amount>
+          </S.TextBox>
+        </S.SumBox>
+      </S.Box>
+    </>
+  );
 };
 
 export default FixedExpenditure;

--- a/client/src/container/FixedExpenditure/styles.ts
+++ b/client/src/container/FixedExpenditure/styles.ts
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+const DefaultStyle = styled.div`
+  border-radius: 0.3rem;
+  box-shadow: 1px 2px 4px 1px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+`;
+
+export const Box = styled(DefaultStyle)`
+  max-width: 100%;
+  width: 100%;
+  margin-top: 1rem;
+`;
+
+export const HeaderBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+`;
+
+export const HeaderTitle = styled.h3`
+  font-size: 1.2rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+
+  p {
+    margin-bottom: 5px;
+  }
+`;
+
+export const SumBox = styled.div`
+  display: flex;
+  align-items: center;
+  & + & {
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+  }
+  svg {
+    color: #0e7ee0;
+    margin-right: 0.8rem;
+  }
+`;
+export const TextBox = styled.div``;
+
+export const SumTitle = styled.p`
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+`;
+
+export const Amount = styled.p`
+  font-size: 0.9rem;
+`;

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -15,7 +15,6 @@ const rootReducer = combineReducers({
   datePicker,
 });
 
-
 export default rootReducer;
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/views/DetailedFixedExpenditurePage/index.tsx
+++ b/client/src/views/DetailedFixedExpenditurePage/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import MainLayout from '@/components/common/layouts/MainLayout';
+import DetailedFixedExpenditure from '@/container/DetailedFixedExpenditure';
+
+const DetailedFixedExpenditurePage = (): JSX.Element => {
+  return (
+    <MainLayout>
+      <DetailedFixedExpenditure />
+    </MainLayout>
+  );
+};
+
+export default DetailedFixedExpenditurePage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,6 +7440,16 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
+eslint-webpack-plugin@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-2.3.0.tgz#28f8521176abc9139d29dcfdf3991b1345041667"
+  integrity sha512-PChgcT7U0p4exEgaWts+1sdybBgrluWOfpzmZOsDR6L0nPtvEkykxY7KUEv8RFNwCyjga8hneqsnJvTfhPCX3Q==
+  dependencies:
+    "@types/eslint" "^7.2.4"
+    arrify "^2.0.1"
+    micromatch "^4.0.2"
+    schema-utils "^3.0.0"
+
 eslint-webpack-plugin@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.0.tgz#dcfd2653d0e15e52251f34dd3690ce60718d5589"
@@ -13810,6 +13820,11 @@ react-hotkeys@2.0.0:
   integrity sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==
   dependencies:
     prop-types "^15.6.1"
+
+react-icons@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.1.0.tgz#9ca9bcbf2e3aee8e86e378bb9d465842947bbfc3"
+  integrity sha512-FCXBg1JbbR0vWALXIxmFAfozHdVIJmmwCD81Jk0EKOt7Ax4AdBNcaRkWhR0NaKy9ugJgoY3fFvo0PHpte55pXg==
 
 react-inspector@^5.0.1:
   version "5.1.0"


### PR DESCRIPTION
### Issue Number

Close #118 

### 변경사항
- MainLayout에 Authorization 추가

### 새로운 기능
- 대시보드에 들어갈 고정 지출 컨테이너 구현
- 고정 지출 상세 페이지 구현
![대시보드](https://user-images.githubusercontent.com/66261552/101076027-2259e900-35e6-11eb-87a8-d3bf061d7668.PNG)
![상세페이지](https://user-images.githubusercontent.com/66261552/101076073-343b8c00-35e6-11eb-9f98-06c385ddbb95.PNG)

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
