### PR TITLE
고정 지출 완료, 예정으로 분리, 회원가입 날짜 상태 관리

### DIFF
--- a/client/src/commons/types/fixedExpenditure.ts
+++ b/client/src/commons/types/fixedExpenditure.ts
@@ -1,7 +1,11 @@
-export type FixedExpenditure = {
+export type FixedData = {
   fid: number;
   tradeAt: Date;
   amount: number;
   description: string;
-  uid: number;
+};
+
+export type FixedExpenditure = {
+  paid: FixedData[];
+  estimated: FixedData[];
 };

--- a/client/src/components/fixedExpenditure/Item/index.tsx
+++ b/client/src/components/fixedExpenditure/Item/index.tsx
@@ -3,14 +3,17 @@ import numberUtils from '@libs/numberUtils';
 import { FixedExpenditureItemPropType } from './types';
 import * as S from './styles';
 
-const FixedExpenditureItem = ({ fixedItem }: FixedExpenditureItemPropType): JSX.Element => {
+const FixedExpenditureItem = ({ fixedItem, isPaid }: FixedExpenditureItemPropType): JSX.Element => {
   return (
     <S.Box>
       <S.TitleBox>
         <S.Description>{fixedItem.description}</S.Description>
-        <S.Amount>약 {numberUtils.numberWithCommas(fixedItem.amount)} 원</S.Amount>
+        <S.Amount>
+          {isPaid ? '' : '약 '}
+          {numberUtils.numberWithCommas(fixedItem.amount)} 원
+        </S.Amount>
       </S.TitleBox>
-      <S.Date>{fixedItem.tradeAt.toString().substring(8)}일</S.Date>
+      <S.Date>{fixedItem.tradeAt.toString().substring(8, 10)}일</S.Date>
     </S.Box>
   );
 };

--- a/client/src/components/fixedExpenditure/Item/styles.ts
+++ b/client/src/components/fixedExpenditure/Item/styles.ts
@@ -11,16 +11,16 @@ export const TitleBox = styled.div``;
 export const Description = styled.p`
   font-size: 1.2rem;
   font-weight: 600;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.6rem;
 `;
 
 export const Amount = styled.p`
   font-weight: 600;
-  color: #a4a4a4;
+  color: #6f6f6f;
 `;
 
 export const Date = styled.p`
   font-size: 1.2rem;
   font-weight: 600;
-  color: #a4a4a4;
+  color: #6f6f6f;
 `;

--- a/client/src/components/fixedExpenditure/Item/types.ts
+++ b/client/src/components/fixedExpenditure/Item/types.ts
@@ -1,5 +1,6 @@
-import { FixedExpenditure } from '@/commons/types/fixedExpenditure';
+import { FixedData } from '@/commons/types/fixedExpenditure';
 
 export type FixedExpenditureItemPropType = {
-  fixedItem: FixedExpenditure;
+  fixedItem: FixedData;
+  isPaid: boolean;
 };

--- a/client/src/container/Authorization/index.tsx
+++ b/client/src/container/Authorization/index.tsx
@@ -8,12 +8,12 @@ import { login } from '@/modules/authorization/actions';
 const Authorization = (): JSX.Element => {
   const history = useHistory();
   const dispatch = useDispatch();
-  const isLoggedIn = useSelector((state: RootState) => state.authorization.isLoggedIn);
+  const createAt = useSelector((state: RootState) => state.authorization.createAt);
   const checkLogin = useCallback(async () => {
-    if (!isLoggedIn) {
+    if (!createAt) {
       try {
-        await authorizationAPI.isLogin();
-        dispatch(login());
+        const inputCreateAt = await authorizationAPI.isLogin();
+        dispatch(login({ createAt: inputCreateAt }));
       } catch (error) {
         console.log(error);
         history.push('/');

--- a/client/src/container/DetailedFixedExpenditure/index.tsx
+++ b/client/src/container/DetailedFixedExpenditure/index.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect } from 'react';
 import { getFixedExpenditureThunk } from '@modules/fixedExpenditure';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/modules';
-import dateUtils from '@libs/dateUtils';
 import numberUtils from '@libs/numberUtils';
 import FixedExpenditureItem from '@components/fixedExpenditure/Item';
 import * as S from './styles';
@@ -13,21 +12,37 @@ const DetailedFixedExpenditure = (): JSX.Element => {
   const dispatch = useDispatch();
 
   const getFixedExpenditure = useCallback(() => {
-    const { startDate, endDate } = dateUtils.getStartEndDate(datePicker.year, datePicker.month);
-    dispatch(getFixedExpenditureThunk(startDate, endDate));
+    dispatch(getFixedExpenditureThunk(datePicker.year, datePicker.month));
   }, [dispatch, datePicker]);
 
-  const getSumFixedExpenditure = useCallback(() => {
-    const { data } = fixedExpenditure.fixedExpenditure;
-    if (data) {
+  const getAmount = useCallback(
+    (type: string) => {
+      const { data } = fixedExpenditure;
       let sum = 0;
-      for (const value of data) {
-        sum += value.amount;
+      if (data) {
+        if (type === 'estimated') {
+          data.estimated.forEach((temp) => {
+            sum += temp.amount;
+          });
+        } else if (type === 'paid') {
+          data.paid.forEach((temp) => {
+            sum += temp.amount;
+          });
+        } else {
+          data.estimated.forEach((temp) => {
+            sum += temp.amount;
+          });
+          data.paid.forEach((temp) => {
+            sum += temp.amount;
+          });
+        }
+
+        return numberUtils.numberWithCommas(sum);
       }
-      return numberUtils.numberWithCommas(sum);
-    }
-    return 0;
-  }, [fixedExpenditure]);
+      return sum;
+    },
+    [fixedExpenditure],
+  );
 
   useEffect(() => {
     getFixedExpenditure();
@@ -36,19 +51,38 @@ const DetailedFixedExpenditure = (): JSX.Element => {
     <>
       <S.Box>
         <S.Title>고정적인 지출</S.Title>
-        <S.Amount>총 {getSumFixedExpenditure()} 원</S.Amount>
+        <S.Amount>총 {getAmount('both')} 원</S.Amount>
       </S.Box>
-      <S.Box>
-        {fixedExpenditure.fixedExpenditure.data ? (
-          fixedExpenditure.fixedExpenditure.data.map((fixedItem) => (
-            <S.ItemBox key={fixedItem.fid}>
-              <FixedExpenditureItem fixedItem={fixedItem} />
-            </S.ItemBox>
-          ))
-        ) : (
-          <div />
-        )}
-      </S.Box>
+      {fixedExpenditure.data?.paid.length !== 0 ? (
+        <>
+          <S.Box>
+            <S.Category color="#E73636">지출 완료</S.Category>
+            {fixedExpenditure.data?.paid.map((fixedItem) => (
+              <S.ItemBox key={`fixed${fixedItem.fid}`}>
+                <FixedExpenditureItem fixedItem={fixedItem} isPaid />
+              </S.ItemBox>
+            ))}
+            <S.AmountBox>
+              <p>지출 완료 합계</p>
+              <p>{getAmount('paid')}원</p>
+            </S.AmountBox>
+          </S.Box>
+          <S.Box>
+            <S.Category color="#0e7ee0">지출 예정</S.Category>
+            {fixedExpenditure.data?.estimated.map((fixedItem) => (
+              <S.ItemBox key={`fixed${fixedItem.fid}`}>
+                <FixedExpenditureItem fixedItem={fixedItem} isPaid={false} />
+              </S.ItemBox>
+            ))}
+            <S.AmountBox>
+              <p>지출 예정 합계</p>
+              <p>{getAmount('estimated')}원</p>
+            </S.AmountBox>
+          </S.Box>
+        </>
+      ) : (
+        <div />
+      )}
     </>
   );
 };

--- a/client/src/container/DetailedFixedExpenditure/styles.ts
+++ b/client/src/container/DetailedFixedExpenditure/styles.ts
@@ -21,7 +21,7 @@ export const Title = styled.p`
 export const Amount = styled.p`
   font-size: 1.2rem;
   font-weight: 600;
-  color: #a4a4a4;
+  color: #6f6f6f;
 `;
 
 export const ItemBox = styled.div`
@@ -29,4 +29,22 @@ export const ItemBox = styled.div`
   & + & {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
   }
+`;
+
+export const AmountBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-top: 0.8rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  font-size: 0.9rem;
+`;
+
+export const Category = styled.p`
+  width: 4rem;
+  padding: 0.2rem;
+  color: white;
+  background-color: ${(props) => props.color || '#d1d1d1'};
+  border-radius: 5px;
+  font-size: 0.8rem;
+  text-align: center;
 `;

--- a/client/src/container/FixedExpenditure/index.tsx
+++ b/client/src/container/FixedExpenditure/index.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect } from 'react';
 import { getFixedExpenditureThunk } from '@modules/fixedExpenditure';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/modules';
-import dateUtils from '@libs/dateUtils';
 import { Link } from 'react-router-dom';
 import { GoCalendar } from 'react-icons/go';
 import numberUtils from '@libs/numberUtils';
@@ -14,21 +13,30 @@ const FixedExpenditure = (): JSX.Element => {
   const dispatch = useDispatch();
 
   const getFixedExpenditure = useCallback(() => {
-    const { startDate, endDate } = dateUtils.getStartEndDate(datePicker.year, datePicker.month);
-    dispatch(getFixedExpenditureThunk(startDate, endDate));
+    dispatch(getFixedExpenditureThunk(datePicker.year, datePicker.month));
   }, [dispatch, datePicker]);
 
-  const getSumFixedExpenditure = useCallback(() => {
-    const { data } = fixedExpenditure.fixedExpenditure;
-    if (data) {
+  const getAmount = useCallback(
+    (type: string) => {
+      const { data } = fixedExpenditure;
       let sum = 0;
-      for (const value of data) {
-        sum += value.amount;
+      if (data) {
+        if (type === 'estimated') {
+          data.estimated.forEach((temp) => {
+            sum += temp.amount;
+          });
+        } else {
+          data.paid.forEach((temp) => {
+            sum += temp.amount;
+          });
+        }
+
+        return numberUtils.numberWithCommas(sum);
       }
-      return numberUtils.numberWithCommas(sum);
-    }
-    return 0;
-  }, [fixedExpenditure]);
+      return sum;
+    },
+    [fixedExpenditure],
+  );
 
   useEffect(() => {
     getFixedExpenditure();
@@ -39,15 +47,22 @@ const FixedExpenditure = (): JSX.Element => {
         <S.HeaderBox>
           <S.HeaderTitle>
             <p>예정된 고정지출이</p>
-            <p>{fixedExpenditure.fixedExpenditure.data?.length}개 있어요</p>
+            <p>{fixedExpenditure.data?.estimated.length}개 있어요</p>
           </S.HeaderTitle>
           <Link to="/detailed-fixed-expenditure">자세히 보기</Link>
         </S.HeaderBox>
         <S.SumBox>
-          <GoCalendar />
+          <GoCalendar color="red" />
+          <S.TextBox>
+            <S.SumTitle>완료된 고정 지출</S.SumTitle>
+            <S.Amount>{getAmount('paid')}원</S.Amount>
+          </S.TextBox>
+        </S.SumBox>
+        <S.SumBox>
+          <GoCalendar color="#0e7ee0" />
           <S.TextBox>
             <S.SumTitle>예정된 고정 지출</S.SumTitle>
-            <S.Amount>{getSumFixedExpenditure()}원</S.Amount>
+            <S.Amount>{getAmount('estimated')}원</S.Amount>
           </S.TextBox>
         </S.SumBox>
       </S.Box>

--- a/client/src/container/FixedExpenditure/styles.ts
+++ b/client/src/container/FixedExpenditure/styles.ts
@@ -31,11 +31,11 @@ export const HeaderTitle = styled.h3`
 export const SumBox = styled.div`
   display: flex;
   align-items: center;
+  padding: 0.8rem 0 0.8rem 0;
   & + & {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
   }
   svg {
-    color: #0e7ee0;
     margin-right: 0.8rem;
   }
 `;

--- a/client/src/libs/api/Authorization.ts
+++ b/client/src/libs/api/Authorization.ts
@@ -2,8 +2,10 @@ import axios from '@/libs/axios';
 import endplints from '@/libs/endpoints';
 
 const authorizationAPI = {
-  isLogin: async (): Promise<void> => {
-    await axios.get<void>(`${endplints.AUTH_API}/isLogin`);
+  isLogin: async (): Promise<Date> => {
+    const createAt = await axios.get<Date>(`${endplints.AUTH_API}/isLogin`);
+
+    return createAt;
   },
 };
 

--- a/client/src/libs/api/fixedExpenditure.ts
+++ b/client/src/libs/api/fixedExpenditure.ts
@@ -3,9 +3,9 @@ import endpoints from '@/libs/endpoints';
 import { FixedExpenditure } from '@/commons/types/fixedExpenditure';
 
 const fixedExpenditureAPI = {
-  getFixedExpenditure: async (startDate: string, endDate: string): Promise<FixedExpenditure[]> => {
+  getFixedExpenditure: async (year: number, month: number): Promise<FixedExpenditure[]> => {
     const fixedExpenditure = await axios.get<FixedExpenditure[]>(
-      `${endpoints.FIXED_EXPENDITURE_API}?start=${startDate}&end=${endDate}`,
+      `${endpoints.FIXED_EXPENDITURE_API}?year=${year}&month=${month}`,
     );
     return fixedExpenditure;
   },

--- a/client/src/modules/authorization/reducer.ts
+++ b/client/src/modules/authorization/reducer.ts
@@ -1,14 +1,15 @@
 import { handleActions } from 'redux-actions';
 import { LOGIN, LOGOUT } from './actions';
+import { AuthorizationState } from './types';
 
-const initialState = {
-  isLoggedIn: false,
+const initialState: AuthorizationState = {
+  createAt: null,
 };
 
 const authorization = handleActions(
   {
-    [LOGIN]: (state, action) => ({ isLoggedIn: true }),
-    [LOGOUT]: (state, action) => ({ isLoggedIn: false }),
+    [LOGIN]: (state, action) => ({ createAt: action.payload.createAt }),
+    [LOGOUT]: (state, action) => ({ createAt: null }),
   },
   initialState,
 );

--- a/client/src/modules/authorization/types.ts
+++ b/client/src/modules/authorization/types.ts
@@ -1,0 +1,3 @@
+export type AuthorizationState = {
+  createAt: Date | null;
+};

--- a/client/src/modules/fixedExpenditure/actions.ts
+++ b/client/src/modules/fixedExpenditure/actions.ts
@@ -10,4 +10,4 @@ export const getFixedExpenditureAsync = createAsyncAction(
   GET_FIXED_EXPENDITURE,
   GET_FIXED_EXPENDITURE_SUCCESS,
   GET_FIXED_EXPENDITURE_FAILURE,
-)<string, FixedExpenditure[], AxiosError>();
+)<string, FixedExpenditure, AxiosError>();

--- a/client/src/modules/fixedExpenditure/reducer.ts
+++ b/client/src/modules/fixedExpenditure/reducer.ts
@@ -7,11 +7,9 @@ import {
 import { FixedExpenditureAction, FixedExpenditureState } from './types';
 
 const initialState: FixedExpenditureState = {
-  fixedExpenditure: {
-    loading: false,
-    error: null,
-    data: null,
-  },
+  loading: false,
+  error: null,
+  data: null,
 };
 
 const fixedExpenditureReducer = createReducer<FixedExpenditureState, FixedExpenditureAction>(
@@ -19,27 +17,21 @@ const fixedExpenditureReducer = createReducer<FixedExpenditureState, FixedExpend
   {
     [GET_FIXED_EXPENDITURE]: (state) => ({
       ...state,
-      fixedExpenditure: {
-        loading: true,
-        error: null,
-        data: null,
-      },
+      loading: true,
+      error: null,
+      data: null,
     }),
     [GET_FIXED_EXPENDITURE_SUCCESS]: (state, action) => ({
       ...state,
-      fixedExpenditure: {
-        loading: false,
-        error: null,
-        data: action.payload,
-      },
+      loading: false,
+      error: null,
+      data: action.payload,
     }),
     [GET_FIXED_EXPENDITURE_FAILURE]: (state, action) => ({
       ...state,
-      fixedExpenditure: {
-        loading: false,
-        error: action.payload,
-        data: null,
-      },
+      loading: false,
+      error: action.payload,
+      data: null,
     }),
   },
 );

--- a/client/src/modules/fixedExpenditure/types.ts
+++ b/client/src/modules/fixedExpenditure/types.ts
@@ -5,9 +5,7 @@ import * as actions from './actions';
 export type FixedExpenditureAction = ActionType<typeof actions>;
 
 export type FixedExpenditureState = {
-  fixedExpenditure: {
-    loading: boolean;
-    error: Error | null;
-    data: FixedExpenditure[] | null;
-  };
+  loading: boolean;
+  error: Error | null;
+  data: FixedExpenditure | null;
 };

--- a/client/src/views/LoginPage/index.tsx
+++ b/client/src/views/LoginPage/index.tsx
@@ -12,8 +12,8 @@ const LoginPage = (props: RouteComponentProps): JSX.Element => {
   useEffect(() => {
     const checkLogin = async () => {
       try {
-        await authorizationAPI.isLogin();
-        dispatch(login());
+        const createAt = await authorizationAPI.isLogin();
+        dispatch(login({ createAt }));
         props.history.push('/dashboard');
       } catch (error) {
         console.log(error);

--- a/server/src/domain/auth/auth.router.ts
+++ b/server/src/domain/auth/auth.router.ts
@@ -19,7 +19,8 @@ class AuthRouter extends Router {
 
   initRouter(): void {
     this.get('/isLogin', jwtAuthorize, (ctx: Context) => {
-      ctx.status = 200;
+      const { createAt } = ctx.state.user;
+      ctx.body = createAt;
     });
 
     this.get('/:provider', (ctx: Context) => {

--- a/server/src/domain/auth/types/user-dto.ts
+++ b/server/src/domain/auth/types/user-dto.ts
@@ -5,6 +5,8 @@ export default class UserDTO {
     this.uid = user.uid;
     this.name = user.name;
     this.socialType = user.socialType;
+    this.updateAt = user.updateAt;
+    this.createAt = user.createAt;
   }
 
   uid: number;
@@ -12,4 +14,8 @@ export default class UserDTO {
   name: string;
 
   socialType: string;
+
+  updateAt: Date | undefined;
+
+  createAt: Date;
 }

--- a/server/src/domain/fixed-expenditure/fixed-expenditure.router.ts
+++ b/server/src/domain/fixed-expenditure/fixed-expenditure.router.ts
@@ -19,9 +19,14 @@ export default class FixedExpenditureRouter extends Router {
 
   initRouter(): void {
     this.get('/', async (ctx: Context) => {
-      const { uid } = ctx.state.user;
-      const { start, end } = ctx.query;
-      const fixedList = await this.fixedExpenditureService.getFixedExpenditure(uid, start, end);
+      const { uid, updateAt } = ctx.state.user;
+      const { year, month } = ctx.query;
+      const fixedList = await this.fixedExpenditureService.getFixedExpenditure(
+        uid,
+        updateAt,
+        year,
+        Number(month) - 1,
+      );
       ctx.body = fixedList;
     });
   }

--- a/server/src/domain/fixed-expenditure/fixed-expenditure.service.ts
+++ b/server/src/domain/fixed-expenditure/fixed-expenditure.service.ts
@@ -29,14 +29,14 @@ export default class FixedExpenditureService {
     month: number,
   ): Promise<ResponseType> {
     const startDate = dateToString(new Date(year, month, 1));
-    const endDate = dateToString(new Date(2020, Number(month) + 1, 0));
+    const endDate = dateToString(new Date(year, Number(month) + 1, 0));
 
     if (!updateAt || updateAt.getFullYear() < year || updateAt.getMonth() < month) {
       await this.createFixedExpenditure(uid, year, month);
     }
 
     const fixedDatas: ResultType[] = await this.fixedExpenditureRepository
-      .query(`select f1.fid, f1.trade_at, f1.amount as estimated_amount, f1.description, t1.amount as paid_amount
+      .query(`select f1.fid, f1.trade_at as tradeAt, f1.amount as estimatedAmount, f1.description, t1.amount as paidAmount
     from (select * from fixed_expenditure where uid=${uid} and trade_at between '${startDate}' and '${endDate}') f1 
     left outer join (select * from transaction where uid=${uid} and trade_at between '${startDate}' and '${endDate}') t1 on f1.uid = t1.uid and f1.trade_at = t1.trade_at
     order by f1.trade_at ASC;`);
@@ -45,18 +45,18 @@ export default class FixedExpenditureService {
     const estimated: FixedType[] = [];
 
     fixedDatas.forEach((fixedData) => {
-      if (fixedData.paid_amount) {
+      if (fixedData.paidAmount) {
         paid.push({
           fid: fixedData.fid,
-          tradeAt: fixedData.trade_at,
-          amount: fixedData.paid_amount,
+          tradeAt: fixedData.tradeAt,
+          amount: fixedData.paidAmount,
           description: fixedData.description,
         });
       } else {
         estimated.push({
           fid: fixedData.fid,
-          tradeAt: fixedData.trade_at,
-          amount: fixedData.estimated_amount,
+          tradeAt: fixedData.tradeAt,
+          amount: fixedData.estimatedAmount,
           description: fixedData.description,
         });
       }

--- a/server/src/domain/fixed-expenditure/types.ts
+++ b/server/src/domain/fixed-expenditure/types.ts
@@ -15,10 +15,10 @@ export type InputType = {
 
 export type ResultType = {
   fid: number;
-  trade_at: Date;
-  estimated_amount: number;
+  tradeAt: Date;
+  estimatedAmount: number;
   description: string;
-  paid_amount: number | null;
+  paidAmount: number | null;
 };
 
 export type ResponseType = {

--- a/server/src/domain/fixed-expenditure/types.ts
+++ b/server/src/domain/fixed-expenditure/types.ts
@@ -1,6 +1,27 @@
+/* eslint-disable camelcase */
 export type FixedType = {
+  fid: number;
+  tradeAt: Date;
+  amount: number;
+  description: string;
+};
+
+export type InputType = {
   tradeAt: Date;
   amount: number;
   description: string;
   uid: number;
+};
+
+export type ResultType = {
+  fid: number;
+  trade_at: Date;
+  estimated_amount: number;
+  description: string;
+  paid_amount: number | null;
+};
+
+export type ResponseType = {
+  paid: FixedType[];
+  estimated: FixedType[];
 };

--- a/server/src/entity/user.entity.ts
+++ b/server/src/entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import CategoryEntity from './category.entity';
 import FixedExpenditureEntity from './fixed-expenditure.entity';
 import PaymentEntity from './payment.entity';
@@ -26,6 +26,9 @@ export default class UserEntity {
 
   @Column({ type: 'date', nullable: true })
   updateAt!: Date | undefined;
+
+  @CreateDateColumn()
+  createAt!: Date;
 
   @OneToMany(() => CategoryEntity, (category) => category.user, { cascade: true })
   categories?: CategoryEntity[];

--- a/server/src/lib/dateUtils.ts
+++ b/server/src/lib/dateUtils.ts
@@ -1,0 +1,7 @@
+const dateToString = (date: Date): string => {
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+};
+
+export default dateToString;


### PR DESCRIPTION
### Issue Number

Close #140 #141 

### 변경사항
- 로그인 하면 회원가입 날짜를 상태로 관리

### 새로운 기능
- 고정 지출을 완료, 예정으로 분리하여 관리
![대시보드](https://user-images.githubusercontent.com/66261552/101487946-40d33200-39a2-11eb-8a07-1afe71fd4580.PNG)

![상세 페이지](https://user-images.githubusercontent.com/66261552/101487953-43358c00-39a2-11eb-9fc8-9c981126e971.PNG)


### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
