### PR TITLE
SMS 결제정보 파싱 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -39,6 +39,22 @@
         "tsx": "never",
         "json": "never"
       }
+    ],
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "required": {
+          "some": ["nesting", "id"]
+        }
+      }
+    ],
+    "jsx-a11y/label-has-for": [
+      "error",
+      {
+        "required": {
+          "some": ["nesting", "id"]
+        }
+      }
     ]
   }
 }

--- a/client/src/commons/dto/transaction-request.ts
+++ b/client/src/commons/dto/transaction-request.ts
@@ -3,7 +3,7 @@ import { PostTransactionRequest } from '../types/transaction';
 export default class TransactionRequestDTO {
   isIncome: boolean;
 
-  tradeAt: Date;
+  tradeAt: string;
 
   cid: number;
 

--- a/client/src/commons/types/transaction.ts
+++ b/client/src/commons/types/transaction.ts
@@ -25,8 +25,8 @@ export type TransactionModel = {
 export type MonthTransactionsResponse = { date: YearMonthModel; list: TransactionModel[] };
 
 export type PostTransactionRequest = {
-  amount: number;
-  tradeAt: Date;
+  amount: string;
+  tradeAt: string;
   description: string;
   isIncome: string;
   cid: number;

--- a/client/src/components/common/Modal/styles.tsx
+++ b/client/src/components/common/Modal/styles.tsx
@@ -21,8 +21,9 @@ export const Modal = styled.div<ModalProps>`
 
 export const Container = styled.div`
   width: 100%;
-  max-width: 40rem;
+  max-width: 500px;
   margin: 0rem 2rem;
+  padding: 1.5rem;
 
   z-index: 1100;
   display: flex;

--- a/client/src/components/common/forms/CustomInput/index.tsx
+++ b/client/src/components/common/forms/CustomInput/index.tsx
@@ -4,7 +4,7 @@ import { InputButtonProps } from './types';
 
 const CustomInput = forwardRef<HTMLInputElement, InputButtonProps>(
   (props: InputButtonProps, ref): JSX.Element => {
-    const { placeholder, inputType, name, onChange, initialValue } = props;
+    const { placeholder, inputType, name, onChange, value } = props;
     return (
       <StyledInput
         name={name}
@@ -12,7 +12,7 @@ const CustomInput = forwardRef<HTMLInputElement, InputButtonProps>(
         type={inputType === 'calendar' ? 'date' : 'text'}
         placeholder={placeholder}
         inputType={inputType}
-        defaultValue={initialValue || ''}
+        value={value || ''}
         ref={ref}
       />
     );

--- a/client/src/components/common/forms/CustomInput/types.ts
+++ b/client/src/components/common/forms/CustomInput/types.ts
@@ -3,6 +3,6 @@ export type InputButtonProps = {
   inputType: 'amount' | 'description' | 'calendar';
   name?: string;
   onChange?: any;
-  initialValue?: string;
+  value?: string;
   ref?: React.Ref<HTMLInputElement>;
 };

--- a/client/src/components/manage/ManageItemInput/index.tsx
+++ b/client/src/components/manage/ManageItemInput/index.tsx
@@ -17,12 +17,7 @@ const ManageItemInput = ({
   return (
     <S.ManageItemInputContainer>
       <S.ManageInputBoxContainer>
-        <CustomInput
-          inputType="amount"
-          initialValue={name}
-          placeholder={name}
-          ref={inputComponent}
-        />
+        <CustomInput inputType="amount" value={name} placeholder={name} ref={inputComponent} />
       </S.ManageInputBoxContainer>
       <S.ManageButtonContainer>
         <CustomButton color="white" size="sm" onClickEvent={cancelHandler}>

--- a/client/src/components/transaction/ModalRadioButton/index.tsx
+++ b/client/src/components/transaction/ModalRadioButton/index.tsx
@@ -14,24 +14,26 @@ function ModalRadioButton({ setIsIncome, onChange, value }: ModalRadioButtonProp
     <S.RadioButtonContainer>
       <S.RadioButtonWrapper>
         <S.RadioButton
+          id="radio-withdraw"
           type="radio"
           name="isIncome"
           value="false"
           onChange={onChangeRadioButton}
           defaultChecked
           checked={!value}
-        />{' '}
-        지출
+        />
+        <label htmlFor="radio-withdraw">지출</label>
       </S.RadioButtonWrapper>
       <S.RadioButtonWrapper>
         <S.RadioButton
+          id="radio-income"
           type="radio"
           name="isIncome"
           value="true"
           onChange={onChangeRadioButton}
           checked={!!value}
         />
-        수입
+        <label htmlFor="radio-income">수입</label>
       </S.RadioButtonWrapper>
     </S.RadioButtonContainer>
   );

--- a/client/src/components/transaction/ModalRadioButton/index.tsx
+++ b/client/src/components/transaction/ModalRadioButton/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import * as S from './styles';
 import { ModalRadioButtonProps } from './types';
 
-function ModalRadioButton({ setIsIncome, onChange }: ModalRadioButtonProps): JSX.Element {
+function ModalRadioButton({ setIsIncome, onChange, value }: ModalRadioButtonProps): JSX.Element {
   const onChangeRadioButton = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
-    const isIncome = value === 'true';
+    const { value: targetValue } = event.target;
+    const isIncome = targetValue === 'true';
     setIsIncome(isIncome);
     onChange(event);
   };
@@ -19,11 +19,18 @@ function ModalRadioButton({ setIsIncome, onChange }: ModalRadioButtonProps): JSX
           value="false"
           onChange={onChangeRadioButton}
           defaultChecked
+          checked={!value}
         />{' '}
         지출
       </S.RadioButtonWrapper>
       <S.RadioButtonWrapper>
-        <S.RadioButton type="radio" name="isIncome" value="true" onChange={onChangeRadioButton} />
+        <S.RadioButton
+          type="radio"
+          name="isIncome"
+          value="true"
+          onChange={onChangeRadioButton}
+          checked={!!value}
+        />
         수입
       </S.RadioButtonWrapper>
     </S.RadioButtonContainer>

--- a/client/src/components/transaction/ModalRadioButton/types.ts
+++ b/client/src/components/transaction/ModalRadioButton/types.ts
@@ -3,4 +3,5 @@ import { Dispatch, SetStateAction } from 'react';
 export type ModalRadioButtonProps = {
   setIsIncome: Dispatch<SetStateAction<boolean>>;
   onChange: any;
+  value?: boolean;
 };

--- a/client/src/container/TransactionModal/index.tsx
+++ b/client/src/container/TransactionModal/index.tsx
@@ -64,9 +64,12 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
       if (parsedText.amount === 0) {
         infoDispatch({
           ...newTransaction,
+          tradeAt: '',
+          isIncome: 'false',
           amount: `${parsedText.amount}`,
           description: clipText,
         });
+        setIsIncome(false);
       } else {
         const { year: thisYear } = DateUtils.parseDate(new Date());
         const formattedDate = DateUtils.formatString(new Date(`${thisYear}/${parsedText.date}`));

--- a/client/src/container/TransactionModal/styles.tsx
+++ b/client/src/container/TransactionModal/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const ModalHeader = styled.div`
   display: flex;
   flex-direction: row;
-  width: 85%;
+  width: 100%;
   padding: 1rem 0rem;
   justify-content: space-between;
   align-items: center;
@@ -14,13 +14,13 @@ export const ModalBody = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  width: 85%;
+  width: 100%;
 `;
 
 export const ModalFooter = styled.div`
   display: flex;
   flex-direction: row;
-  width: 85%;
+  width: 100%;
   padding: 0.3rem 0rem;
   justify-content: space-between;
   align-items: center;

--- a/client/src/libs/dateUtils.ts
+++ b/client/src/libs/dateUtils.ts
@@ -15,6 +15,13 @@ const parseDate = (date: Date | string): ParsedDateModel => {
   };
 };
 
+const formatString = (date: Date): string => {
+  const { year: yearToken, month: monthToken, date: dateToken } = parseDate(date);
+  return `${yearToken}-${monthToken >= 10 ? monthToken : `0${monthToken}`}-${
+    dateToken >= 10 ? `${dateToken}` : `0${dateToken}`
+  }`;
+};
+
 type StartEndDate = {
   startDate: string;
   endDate: string;
@@ -67,4 +74,10 @@ const makeDataForLineGraph = (aggregateInfo: AggregateInfo, year: number, month:
   return { maxTotal, graphData };
 };
 
-export default { parseDate, getStartEndDate, getEndDateOfMonth, makeDataForLineGraph };
+export default {
+  parseDate,
+  formatString,
+  getStartEndDate,
+  getEndDateOfMonth,
+  makeDataForLineGraph,
+};

--- a/client/src/libs/smsParser/parser.test.ts
+++ b/client/src/libs/smsParser/parser.test.ts
@@ -234,4 +234,20 @@ describe('SMSParser Tests', () => {
       });
     });
   });
+
+  describe('예외처리 Tests', () => {
+    it('결제내역에 대한 텍스트가 아닐때', () => {
+      const sms = '이것은 결제내역에 대한 텍스트가 아닙니다.';
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '',
+        amount: 0,
+        date: '',
+        time: '',
+        paymentType: '',
+        isDeposit: false,
+      });
+    });
+  });
 });

--- a/client/src/libs/smsParser/parser.test.ts
+++ b/client/src/libs/smsParser/parser.test.ts
@@ -1,0 +1,237 @@
+import SMSParser from './parser';
+
+describe('SMSParser Tests', () => {
+  describe('카드결제 내역 parse tests', () => {
+    it('kg이니시스 승인', () => {
+      const sms = `[WEB발신]
+              [kg이니시스]
+              04/12 21:13
+              464,000원 익월
+              합산요금청구`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: 'KG',
+        amount: 464000,
+        date: '04/12',
+        time: '21:13',
+        resultType: '승인',
+        paymentType: '신용카드',
+        isDeposit: false,
+      });
+    });
+
+    it('KB국민카드 승인', () => {
+      const sms = `[WEB발신]
+              KB국민카드 김영근님 06/07
+              09:22 5000원
+              결제 승인`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: 'KB',
+        amount: 5000,
+        date: '06/07',
+        time: '09:22',
+        resultType: '승인',
+        paymentType: '신용카드',
+        isDeposit: false,
+      });
+    });
+
+    it('KB국민체크카드 승인취소', () => {
+      const sms = `[Web발신]
+                KB국민체크카드
+                윤*우님
+                06/08 08:57
+                28,440원
+                11PAY 인증
+                승인취소
+                `;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: 'KB',
+        amount: 28440,
+        date: '06/08',
+        time: '08:57',
+        resultType: '취소',
+        paymentType: '체크카드',
+        isDeposit: true,
+      });
+    });
+
+    it('현대카드 승인', () => {
+      const sms = `현대 ZERO 승인
+            2,500원 일시불
+            04/10 13:15
+            코레일유통서울지사
+            누적 560,852원
+            0.7%할인`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '현대',
+        amount: 2500,
+        date: '04/10',
+        time: '13:15',
+        resultType: '승인',
+        paymentType: '신용카드',
+        isDeposit: false,
+      });
+    });
+
+    it('신한체크카드 승인', () => {
+      const sms = `[Web발신]
+              [신한체크카드승인] 최*희(7062)
+              02/10 13:10
+              (금액)1,000원 PAYCO`;
+
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '신한',
+        amount: 1000,
+        date: '02/10',
+        time: '13:10',
+        resultType: '승인',
+        paymentType: '체크카드',
+        isDeposit: false,
+      });
+    });
+
+    it('롯데카드 승인', () => {
+      const sms = `롯데3121 승인
+              5,200원 일시불
+              09/15 18:31
+              월드크리닝 롯데마트`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '롯데',
+        amount: 5200,
+        date: '09/15',
+        time: '18:31',
+        resultType: '승인',
+        paymentType: '신용카드',
+        isDeposit: false,
+      });
+    });
+
+    it('우리 체크카드 승인', () => {
+      const sms = `[Web발신]
+              우리(8804) 체크카드승인
+              윤*우님
+              10,000원
+              11/03 10:03
+              스타벅스코리아`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '우리',
+        amount: 10000,
+        date: '11/03',
+        time: '10:03',
+        resultType: '승인',
+        paymentType: '체크카드',
+        isDeposit: false,
+      });
+    });
+
+    it('우리카드 승인취소', () => {
+      const sms = `[Web발신]
+              우리(4575)승인취소
+              임*봉님
+              4562원 일시불 
+              12/07 20:29
+              네이버페이
+              누적123,456원`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '우리',
+        amount: 4562,
+        date: '12/07',
+        time: '20:29',
+        resultType: '취소',
+        paymentType: '신용카드',
+        isDeposit: true,
+      });
+    });
+
+    it('농협카드 승인', () => {
+      const sms = `[Web발신]
+      NH카드7*9*승인
+      박*용
+      12,350원 체크
+      12/06 20:37
+      세븐일레븐 고대안암고 
+      잔액222,210원`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: 'NH',
+        amount: 12350,
+        date: '12/06',
+        time: '20:37',
+        resultType: '승인',
+        paymentType: '체크카드',
+        isDeposit: false,
+      });
+    });
+  });
+
+  describe('이체내역 문자 parse tests', () => {
+    it('농협 입금', () => {
+      const sms = `[Web발신]
+              농협 입금 200원
+              06/11 22:29 123-1234-4567-12
+              잔액 200000원`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '농협',
+        amount: 200,
+        date: '06/11',
+        time: '22:29',
+        paymentType: '이체',
+        isDeposit: true,
+      });
+    });
+
+    it('농협 출금', () => {
+      const sms = `농협 출금 5000원
+                08/31 19:01 123-1234-1234-12
+                잔액 200000원`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '농협',
+        amount: 5000,
+        date: '08/31',
+        time: '19:01',
+        paymentType: '이체',
+        isDeposit: false,
+      });
+    });
+
+    it('신한은행 출금', () => {
+      const sms = `[Web발신]
+      [신한은행] 09/26
+      21:31:30.27
+      [110-***-123456]
+      지급 20,000원
+      (최창희)`;
+      const parsedSMS = SMSParser.parse(sms);
+
+      expect(parsedSMS).toEqual({
+        cardname: '신한',
+        amount: 20000,
+        date: '09/26',
+        time: '21:31',
+        paymentType: '이체',
+        isDeposit: false,
+      });
+    });
+  });
+});

--- a/client/src/libs/smsParser/parser.ts
+++ b/client/src/libs/smsParser/parser.ts
@@ -1,0 +1,77 @@
+import { ParsedSMS } from './types';
+
+const tokenize = (sms: string) => {
+  return sms
+    .replace(/\[web발신\]/i, '')
+    .trim()
+    .split(/[\s\n\r]/g)
+    .filter((e) => e);
+};
+
+const parsePaymentType = (sms: string) => {
+  const paymentTypeTokens = sms.match('입금|출금|지급');
+  if (paymentTypeTokens) {
+    const [paymentType] = paymentTypeTokens;
+    return {
+      paymentType: '이체',
+      isDeposit: paymentType === '입금',
+    };
+  }
+
+  const cardTypeTokens = sms.match('체크');
+  const resultTypeTokens = sms.match('취소|거절');
+  const resultType = resultTypeTokens ? resultTypeTokens[0] : '승인';
+
+  return {
+    paymentType: cardTypeTokens ? '체크카드' : '신용카드',
+    isDeposit: resultType === '취소',
+    resultType,
+  };
+};
+
+const parsePaymentDetail = (sms: string) => {
+  const paymentDetail = {
+    cardname: '',
+    amount: 0,
+    date: '',
+    time: '',
+  };
+  const smsTokens = tokenize(sms);
+  smsTokens.forEach((token, i) => {
+    if (i === 0) {
+      const cardName = token.replace(/[[\]]/gi, '').substring(0, 2).toUpperCase();
+      paymentDetail.cardname = cardName;
+    }
+    if (token.includes('원') && !paymentDetail.amount) {
+      const amountTokens = token.match(/[0-9]+(,?[0-9]+)+/);
+      const [amount] = amountTokens;
+      if (amount) {
+        paymentDetail.amount = Number(amount.replace(',', ''));
+      }
+      return;
+    }
+    if (token.includes(':')) {
+      const timeTokens = token.match(/[0-9]{2}:[0-9]{2}/);
+      const [time] = timeTokens;
+      if (time) {
+        paymentDetail.time = time;
+      }
+    }
+    if (token.includes('/')) {
+      const dateTokens = token.match(/[0-9]{2}\/[0-9]{2}/);
+      const [date] = dateTokens;
+      if (date) {
+        paymentDetail.date = date;
+      }
+    }
+  });
+  return paymentDetail;
+};
+
+const parse = (sms: string): ParsedSMS => {
+  const paymentType = parsePaymentType(sms);
+  const paymentDetail = parsePaymentDetail(sms);
+  return { ...paymentType, ...paymentDetail };
+};
+
+export default { parse };

--- a/client/src/libs/smsParser/parser.ts
+++ b/client/src/libs/smsParser/parser.ts
@@ -44,24 +44,30 @@ const parsePaymentDetail = (sms: string) => {
     }
     if (token.includes('원') && !paymentDetail.amount) {
       const amountTokens = token.match(/[0-9]+(,?[0-9]+)+/);
-      const [amount] = amountTokens;
-      if (amount) {
-        paymentDetail.amount = Number(amount.replace(',', ''));
+      if (amountTokens) {
+        const [amount] = amountTokens;
+        if (amount) {
+          paymentDetail.amount = Number(amount.replace(',', ''));
+        }
       }
       return;
     }
     if (token.includes(':')) {
       const timeTokens = token.match(/[0-9]{2}:[0-9]{2}/);
-      const [time] = timeTokens;
-      if (time) {
-        paymentDetail.time = time;
+      if (timeTokens) {
+        const [time] = timeTokens;
+        if (time) {
+          paymentDetail.time = time;
+        }
       }
     }
     if (token.includes('/')) {
       const dateTokens = token.match(/[0-9]{2}\/[0-9]{2}/);
-      const [date] = dateTokens;
-      if (date) {
-        paymentDetail.date = date;
+      if (dateTokens) {
+        const [date] = dateTokens;
+        if (date) {
+          paymentDetail.date = date;
+        }
       }
     }
   });

--- a/client/src/libs/smsParser/parser.ts
+++ b/client/src/libs/smsParser/parser.ts
@@ -71,6 +71,16 @@ const parsePaymentDetail = (sms: string) => {
 const parse = (sms: string): ParsedSMS => {
   const paymentType = parsePaymentType(sms);
   const paymentDetail = parsePaymentDetail(sms);
+  if (paymentDetail.amount === 0 && paymentDetail.date === '' && paymentDetail.time === '') {
+    return {
+      cardname: '',
+      amount: 0,
+      date: '',
+      time: '',
+      paymentType: '',
+      isDeposit: false,
+    };
+  }
   return { ...paymentType, ...paymentDetail };
 };
 

--- a/client/src/libs/smsParser/types.ts
+++ b/client/src/libs/smsParser/types.ts
@@ -1,0 +1,9 @@
+export type ParsedSMS = {
+  cardname: string;
+  amount: number;
+  date: string;
+  time: string;
+  resultType?: string;
+  paymentType: string;
+  isDeposit: boolean;
+};


### PR DESCRIPTION
### Issue Number

Close #127

### 변경사항

- CustomInput, ModalRadioButton 수정
  - 파싱된 값을 form에 입력해줄수 있도록 value prop을 추가

### 새로운 기능

- SMS Parser 모듈 구현
  - 수집된 sample을 기준으로 동작을 테스트하고 구현을 진행
- 가계부 입력 모달에 parser 기능 추가
  - 클립보드의 내용을 가져와 파싱을 진행하고 수입/지출, 날짜, 금액, 내용이 매핑되는 상태까지 구현이 되었고 카테고리나 결제수단의 매핑은 미구현 상태입니다.

**수입 내역 동작 예시**

![parser-income](https://user-images.githubusercontent.com/17294694/101525385-97566580-39ce-11eb-9520-3629643cd901.gif)

**지출 내역 동작 예시**

![parser-withdraw](https://user-images.githubusercontent.com/17294694/101525393-9b828300-39ce-11eb-8b00-49632cde7223.gif)

**결제내역에 대한 내용이 아닐때**

![parser-invalid](https://user-images.githubusercontent.com/17294694/101525391-9ae9ec80-39ce-11eb-8cef-da9eab37bd53.gif)

**개선할 부분**
- 카테고리 매핑은 제외하더라도 결제수단 매핑에 대한 처리는 우선적으로 구현이 되어야 할 것 같습니다.
- 상세내역에 sms 내용을 그대로 보여주는 대신 핵심 키워드(결제장소)를 뽑아서 입력해주면 좋을 것 같습니다.

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
