### PR TITLE
사용자의 소비 습관(과소비 지수)을 계산하는 API 구현

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper,
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
 };

--- a/server/src/domain/aggregate/aggregate.router.ts
+++ b/server/src/domain/aggregate/aggregate.router.ts
@@ -28,14 +28,20 @@ export default class AggregateRouter extends Router {
 
     this.get('/max-category', async (ctx: Context) => {
       const { uid } = ctx.state.user;
-      const maxCategory = await this.aggregateService.getMaxCategory(uid);
+      const { year, month } = ctx.query;
+      const maxCategory = await this.aggregateService.getMaxCategory(uid, year, month);
 
       ctx.body = maxCategory;
     });
 
     this.get('/overspending-index', async (ctx: Context) => {
       const { user } = ctx.state;
-      const overspendingIndexInfo = await this.aggregateService.getOverspendingIndex(user);
+      const { year, month } = ctx.query;
+      const overspendingIndexInfo = await this.aggregateService.getOverspendingIndex(
+        user,
+        year,
+        month,
+      );
       ctx.body = overspendingIndexInfo;
     });
   }

--- a/server/src/domain/aggregate/aggregate.router.ts
+++ b/server/src/domain/aggregate/aggregate.router.ts
@@ -1,5 +1,6 @@
 import Router from 'koa-router';
 import { Context } from 'koa';
+import { getCustomRepository } from 'typeorm';
 import TransactionRepository from '@/domain/transaction/transaction.repository';
 import AggregateService from './aggregate.service';
 
@@ -8,7 +9,7 @@ export default class AggregateRouter extends Router {
 
   constructor() {
     super();
-    this.aggregateService = new AggregateService(TransactionRepository.getTransactionRepository());
+    this.aggregateService = new AggregateService(getCustomRepository(TransactionRepository));
   }
 
   initRouter(): void {
@@ -30,6 +31,12 @@ export default class AggregateRouter extends Router {
       const maxCategory = await this.aggregateService.getMaxCategory(uid);
 
       ctx.body = maxCategory;
+    });
+
+    this.get('/overspending-index', async (ctx: Context) => {
+      const { user } = ctx.state;
+      const overspendingIndexInfo = await this.aggregateService.getOverspendingIndex(user);
+      ctx.body = overspendingIndexInfo;
     });
   }
 }

--- a/server/src/domain/aggregate/aggregate.service.ts
+++ b/server/src/domain/aggregate/aggregate.service.ts
@@ -1,6 +1,6 @@
 import TransactionRepository from '@/domain/transaction/transaction.repository';
 import DateUtils from '@/lib/date-utils';
-import UserDTO from '../auth/types/user-dto';
+import UserDTO from '@/domain/auth/types/user-dto';
 import { AggregateData, AggregateResponse, MaxCategory } from './types';
 
 export default class AggregateService {
@@ -94,12 +94,12 @@ export default class AggregateService {
     month: number,
   ): Promise<number> {
     const { startDate, endDate } = DateUtils.getStartDateAndEndDate(year, month);
-    const { sum } = await this.transactionRepository.sumAmount(
-      user.uid,
-      false,
-      DateUtils.dateToString(startDate),
-      DateUtils.dateToString(endDate),
-    );
+    const { sum } = await this.transactionRepository.sumAmountBetween({
+      uid: user.uid,
+      isIncome: false,
+      startDate: DateUtils.dateToString(startDate),
+      endDate: DateUtils.dateToString(endDate),
+    });
 
     return Number(sum || 0);
   }
@@ -112,12 +112,12 @@ export default class AggregateService {
     const startDateOfYear = new Date(year, 0, 1);
     const lastMonth = new Date(year, month - 1, 0);
     const startDate = new Date(Math.max(startDateOfYear.getTime(), user.createAt.getTime()));
-    const { sum } = await this.transactionRepository.sumAmount(
-      user.uid,
-      true,
-      DateUtils.dateToString(startDate),
-      DateUtils.dateToString(lastMonth),
-    );
+    const { sum } = await this.transactionRepository.sumAmountBetween({
+      uid: user.uid,
+      isIncome: true,
+      startDate: DateUtils.dateToString(startDate),
+      endDate: DateUtils.dateToString(lastMonth),
+    });
 
     const numOfMonthFromStartDateToLastMonth = DateUtils.countMonthBetween(startDate, lastMonth);
     const averageIncome = Number(sum || 0) / numOfMonthFromStartDateToLastMonth;

--- a/server/src/domain/aggregate/aggregate.service.ts
+++ b/server/src/domain/aggregate/aggregate.service.ts
@@ -73,22 +73,24 @@ export default class AggregateService {
   ): Promise<{
     overspendingIndex: number;
     averageIncome: number;
-    expenditureThisMonth: number;
+    sumSpendingAmountOfMonth: number;
   }> {
-    const [averageIncome, expenditureThisMonth] = await Promise.all([
+    const [averageIncome, sumSpendingAmountOfMonth] = await Promise.all([
       this.getAverageIncome(user, year, month),
-      this.getSumSpendAmountOfMonth(user, year, month),
+      this.getSumSpendingAmountOfMonth(user, year, month),
     ]);
 
-    const overspendingIndex = averageIncome ? (expenditureThisMonth / averageIncome).toFixed(2) : 0;
+    const overspendingIndex = averageIncome
+      ? (sumSpendingAmountOfMonth / averageIncome).toFixed(2)
+      : 0;
     return {
       overspendingIndex: Number(overspendingIndex),
       averageIncome,
-      expenditureThisMonth,
+      sumSpendingAmountOfMonth,
     };
   }
 
-  private async getSumSpendAmountOfMonth(
+  private async getSumSpendingAmountOfMonth(
     user: UserDTO,
     year: number,
     month: number,

--- a/server/src/domain/aggregate/aggregate.service.ts
+++ b/server/src/domain/aggregate/aggregate.service.ts
@@ -80,7 +80,7 @@ export default class AggregateService {
       this.getExpenditureThisMonth(user),
     ]);
 
-    const overspendingIndex = (expenditureThisMonth / averageIncome).toFixed(2);
+    const overspendingIndex = averageIncome ? (expenditureThisMonth / averageIncome).toFixed(2) : 0;
     return {
       overspendingIndex: Number(overspendingIndex),
       averageIncome,
@@ -105,6 +105,13 @@ export default class AggregateService {
 
   private async getAverageIncome(user: UserDTO): Promise<number> {
     const today = new Date();
+    if (
+      user.createAt.getFullYear() === today.getFullYear() &&
+      user.createAt.getMonth() === today.getMonth()
+    ) {
+      return 0;
+    }
+
     const startDate = new Date(
       Math.max(new Date(today.getFullYear(), 0, 1).getTime(), user.createAt.getTime()),
     );

--- a/server/src/domain/aggregate/aggregate.service.ts
+++ b/server/src/domain/aggregate/aggregate.service.ts
@@ -55,7 +55,9 @@ export default class AggregateService {
     const query = `select category.name, t1.aggregate
     from category, (select cid, sum(amount) as aggregate
     from transaction 
-    where uid=${uid} and trade_at between '${startDate}' and '${endDate}'
+    where uid=${uid} and is_income=${false} and trade_at between '${DateUtils.dateToString(
+      startDate,
+    )}' and '${DateUtils.dateToString(endDate)}'
     group by cid) t1
     where category.cid = t1.cid
     order by t1.aggregate DESC;`;

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -1,0 +1,52 @@
+import { Connection, getConnection, getCustomRepository } from 'typeorm';
+import TestSeeder from '@/seed/test.seed';
+import TransactionRepository from '@/domain/transaction/transaction.repository';
+import AggregateService from './aggregate.service';
+
+let transactionRepository: TransactionRepository;
+let aggregateService: AggregateService;
+let connection: Connection;
+
+describe('TransactionService Tests', () => {
+  beforeAll(async () => {
+    connection = getConnection();
+    transactionRepository = getCustomRepository(TransactionRepository);
+    aggregateService = new AggregateService(transactionRepository);
+  });
+
+  afterEach(async () => {
+    await TestSeeder.clear(connection);
+  });
+
+  describe('getOverspendingIndex() Tests', () => {
+    it('과소비 지수가 정상적으로 생성되는지 확인', async () => {
+      await TestSeeder.up({
+        connection,
+        numOfUsers: 1,
+        numOfTransactionsPerUser: 100,
+        startDate: new Date('2020-05-12'),
+        endDate: new Date('2020-12-31'),
+      });
+      const user = {
+        uid: 1,
+        name: 'testUser',
+        socialType: 'google',
+        updateAt: new Date('2020-05-12'),
+        createAt: new Date('2020-05-12'),
+      };
+      const {
+        overspendingIndex,
+        averageIncome,
+        expenditureThisMonth,
+      } = await aggregateService.getOverspendingIndex(user);
+
+      expect(averageIncome).toBeGreaterThanOrEqual(0);
+      expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);
+      if (averageIncome <= expenditureThisMonth) {
+        expect(overspendingIndex).toBeGreaterThanOrEqual(1);
+      } else {
+        expect(overspendingIndex).toBeLessThan(1);
+      }
+    });
+  });
+});

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -23,7 +23,7 @@ describe('TransactionService Tests', () => {
       await TestSeeder.up({
         connection,
         numOfUsers: 1,
-        numOfTransactionsPerUser: 300,
+        numOfTransactionsPerMonth: 30,
         startDate: new Date('2020-05-12'),
         endDate: new Date('2020-12-31'),
       });
@@ -78,7 +78,7 @@ describe('TransactionService Tests', () => {
       await TestSeeder.up({
         connection,
         numOfUsers: 1,
-        numOfTransactionsPerUser: 100,
+        numOfTransactionsPerMonth: 15,
         startDate: new Date('2020-03-15'),
         endDate: new Date('2020-12-31'),
       });

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -73,5 +73,34 @@ describe('TransactionService Tests', () => {
       expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);
       expect(overspendingIndex).toEqual(0);
     });
+
+    it('유저의 가입일 이전 날짜를 기준으로 과소비 지수가 계산되지 않는다.', async () => {
+      await TestSeeder.up({
+        connection,
+        numOfUsers: 1,
+        numOfTransactionsPerUser: 100,
+        startDate: new Date('2020-03-15'),
+        endDate: new Date('2020-12-31'),
+      });
+
+      const registeredAt = new Date('2020-03-15');
+      const user = {
+        uid: 1,
+        name: 'testUser',
+        socialType: 'google',
+        updateAt: registeredAt,
+        createAt: registeredAt,
+      };
+
+      const {
+        overspendingIndex,
+        averageIncome,
+        expenditureThisMonth,
+      } = await aggregateService.getOverspendingIndex(user, 2020, 2);
+
+      expect(averageIncome).toEqual(0);
+      expect(expenditureThisMonth).toEqual(0);
+      expect(overspendingIndex).toEqual(0);
+    });
   });
 });

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -38,10 +38,10 @@ describe('TransactionService Tests', () => {
         overspendingIndex,
         averageIncome,
         expenditureThisMonth,
-      } = await aggregateService.getOverspendingIndex(user);
+      } = await aggregateService.getOverspendingIndex(user, 2020, 12);
 
-      expect(averageIncome).toBeGreaterThanOrEqual(0);
-      expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);
+      expect(averageIncome).toBeGreaterThan(0);
+      expect(expenditureThisMonth).toBeGreaterThan(0);
       if (averageIncome <= expenditureThisMonth) {
         expect(overspendingIndex).toBeGreaterThanOrEqual(1);
       } else {
@@ -63,7 +63,11 @@ describe('TransactionService Tests', () => {
         overspendingIndex,
         averageIncome,
         expenditureThisMonth,
-      } = await aggregateService.getOverspendingIndex(user);
+      } = await aggregateService.getOverspendingIndex(
+        user,
+        today.getFullYear(),
+        today.getMonth() + 1,
+      );
 
       expect(averageIncome).toEqual(0);
       expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -48,5 +48,26 @@ describe('TransactionService Tests', () => {
         expect(overspendingIndex).toBeLessThan(1);
       }
     });
+
+    it('이번달에 가입한 유저라면 과소비 지수가 계산되지 않는다.', async () => {
+      const today = new Date();
+      const user = {
+        uid: 1,
+        name: 'testUser',
+        socialType: 'google',
+        updateAt: today,
+        createAt: today,
+      };
+
+      const {
+        overspendingIndex,
+        averageIncome,
+        expenditureThisMonth,
+      } = await aggregateService.getOverspendingIndex(user);
+
+      expect(averageIncome).toEqual(0);
+      expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);
+      expect(overspendingIndex).toEqual(0);
+    });
   });
 });

--- a/server/src/domain/aggregate/agreegate.service.test.ts
+++ b/server/src/domain/aggregate/agreegate.service.test.ts
@@ -23,7 +23,7 @@ describe('TransactionService Tests', () => {
       await TestSeeder.up({
         connection,
         numOfUsers: 1,
-        numOfTransactionsPerUser: 100,
+        numOfTransactionsPerUser: 300,
         startDate: new Date('2020-05-12'),
         endDate: new Date('2020-12-31'),
       });
@@ -37,12 +37,12 @@ describe('TransactionService Tests', () => {
       const {
         overspendingIndex,
         averageIncome,
-        expenditureThisMonth,
+        sumSpendingAmountOfMonth,
       } = await aggregateService.getOverspendingIndex(user, 2020, 12);
 
       expect(averageIncome).toBeGreaterThan(0);
-      expect(expenditureThisMonth).toBeGreaterThan(0);
-      if (averageIncome <= expenditureThisMonth) {
+      expect(sumSpendingAmountOfMonth).toBeGreaterThan(0);
+      if (averageIncome <= sumSpendingAmountOfMonth) {
         expect(overspendingIndex).toBeGreaterThanOrEqual(1);
       } else {
         expect(overspendingIndex).toBeLessThan(1);
@@ -62,7 +62,7 @@ describe('TransactionService Tests', () => {
       const {
         overspendingIndex,
         averageIncome,
-        expenditureThisMonth,
+        sumSpendingAmountOfMonth,
       } = await aggregateService.getOverspendingIndex(
         user,
         today.getFullYear(),
@@ -70,7 +70,7 @@ describe('TransactionService Tests', () => {
       );
 
       expect(averageIncome).toEqual(0);
-      expect(expenditureThisMonth).toBeGreaterThanOrEqual(0);
+      expect(sumSpendingAmountOfMonth).toBeGreaterThanOrEqual(0);
       expect(overspendingIndex).toEqual(0);
     });
 
@@ -95,11 +95,11 @@ describe('TransactionService Tests', () => {
       const {
         overspendingIndex,
         averageIncome,
-        expenditureThisMonth,
+        sumSpendingAmountOfMonth,
       } = await aggregateService.getOverspendingIndex(user, 2020, 2);
 
       expect(averageIncome).toEqual(0);
-      expect(expenditureThisMonth).toEqual(0);
+      expect(sumSpendingAmountOfMonth).toEqual(0);
       expect(overspendingIndex).toEqual(0);
     });
   });

--- a/server/src/domain/fixed-expenditure/fixed-expenditure.router.ts
+++ b/server/src/domain/fixed-expenditure/fixed-expenditure.router.ts
@@ -1,5 +1,6 @@
 import Router from 'koa-router';
 import { Context } from 'koa';
+import { getCustomRepository } from 'typeorm';
 import UserRepository from '@/domain/user/user.repository';
 import TransactionRepository from '@/domain/transaction/transaction.repository';
 import FixedExpenditureService from './fixed-expenditure.service';
@@ -13,7 +14,7 @@ export default class FixedExpenditureRouter extends Router {
     this.fixedExpenditureService = new FixedExpenditureService(
       FixedExpenditureRepository.getFixedExpenditureRepository(),
       UserRepository.getUserRepository(),
-      TransactionRepository.getTransactionRepository(),
+      getCustomRepository(TransactionRepository),
     );
   }
 

--- a/server/src/domain/fixed-expenditure/fixed-expenditure.service.ts
+++ b/server/src/domain/fixed-expenditure/fixed-expenditure.service.ts
@@ -2,7 +2,7 @@ import FixedExpenditureEntity from '@/entity/fixed-expenditure.entity';
 import UserEntity from '@/entity/user.entity';
 import TranscationEntity from '@/entity/transaction.entity';
 import { Repository, Between } from 'typeorm';
-import dateToString from '@/lib/dateUtils';
+import DateUtils from '@/lib/date-utils';
 import { FixedType, InputType, ResultType, ResponseType } from './types';
 
 export default class FixedExpenditureService {
@@ -28,8 +28,8 @@ export default class FixedExpenditureService {
     year: number,
     month: number,
   ): Promise<ResponseType> {
-    const startDate = dateToString(new Date(year, month, 1));
-    const endDate = dateToString(new Date(year, Number(month) + 1, 0));
+    const startDate = DateUtils.dateToString(new Date(year, month, 1));
+    const endDate = DateUtils.dateToString(new Date(year, Number(month) + 1, 0));
 
     if (!updateAt || updateAt.getFullYear() < year || updateAt.getMonth() < month) {
       await this.createFixedExpenditure(uid, year, month);

--- a/server/src/domain/transaction/transaction.repository.ts
+++ b/server/src/domain/transaction/transaction.repository.ts
@@ -1,8 +1,24 @@
-import { getRepository, Repository } from 'typeorm';
+import { EntityRepository, Repository } from 'typeorm';
 import TransactionEntity from '@/entity/transaction.entity';
 
-const getTransactionRepository = (): Repository<TransactionEntity> => {
-  return getRepository(TransactionEntity);
-};
+@EntityRepository(TransactionEntity)
+class TransactionRepository extends Repository<TransactionEntity> {
+  sumAmount(
+    uid: number,
+    isIncome: boolean,
+    startDate: string,
+    endDate: string,
+  ): Promise<{ sum: string }> {
+    return this.createQueryBuilder()
+      .select('SUM(amount)', 'sum')
+      .where('uid = :uid', { uid })
+      .andWhere('is_income = :isIncome', { isIncome })
+      .andWhere('trade_at BETWEEN :startDate AND :endDate', {
+        startDate,
+        endDate,
+      })
+      .getRawOne();
+  }
+}
 
-export default { getTransactionRepository };
+export default TransactionRepository;

--- a/server/src/domain/transaction/transaction.repository.ts
+++ b/server/src/domain/transaction/transaction.repository.ts
@@ -3,12 +3,17 @@ import TransactionEntity from '@/entity/transaction.entity';
 
 @EntityRepository(TransactionEntity)
 class TransactionRepository extends Repository<TransactionEntity> {
-  sumAmount(
-    uid: number,
-    isIncome: boolean,
-    startDate: string,
-    endDate: string,
-  ): Promise<{ sum: string }> {
+  sumAmountBetween({
+    uid,
+    isIncome,
+    startDate,
+    endDate,
+  }: {
+    uid: number;
+    isIncome: boolean;
+    startDate: string;
+    endDate: string;
+  }): Promise<{ sum: string }> {
     return this.createQueryBuilder()
       .select('SUM(amount)', 'sum')
       .where('uid = :uid', { uid })

--- a/server/src/domain/transaction/transaction.router.ts
+++ b/server/src/domain/transaction/transaction.router.ts
@@ -1,4 +1,5 @@
 import Router from 'koa-router';
+import { getCustomRepository } from 'typeorm';
 import { Context } from 'koa';
 import TransactionService from './transaction.service';
 import TransactionRepository from './transaction.repository';
@@ -8,9 +9,7 @@ export default class TransactionRouter extends Router {
 
   constructor() {
     super();
-    this.transactionService = new TransactionService(
-      TransactionRepository.getTransactionRepository(),
-    );
+    this.transactionService = new TransactionService(getCustomRepository(TransactionRepository));
   }
 
   initRouter(): void {

--- a/server/src/domain/transaction/transaction.service.test.ts
+++ b/server/src/domain/transaction/transaction.service.test.ts
@@ -1,23 +1,17 @@
-import createDBConnection from '@/loader/database';
-import { Connection, Repository } from 'typeorm';
-import TransactionEntity from '@/entity/transaction.entity';
+import { Connection, getConnection, getCustomRepository } from 'typeorm';
 import TestSeeder from '@/seed/test.seed';
 import TransactionService from './transaction.service';
 import TransactionRepository from './transaction.repository';
 
-let transactionRepository: Repository<TransactionEntity>;
+let transactionRepository: TransactionRepository;
 let transactionService: TransactionService;
 let connection: Connection;
 
 describe('TransactionService Tests', () => {
   beforeAll(async () => {
-    connection = await createDBConnection();
-    transactionRepository = TransactionRepository.getTransactionRepository();
+    connection = getConnection();
+    transactionRepository = getCustomRepository(TransactionRepository);
     transactionService = new TransactionService(transactionRepository);
-  });
-
-  afterAll(async () => {
-    await connection.close();
   });
 
   beforeEach(async () => {

--- a/server/src/domain/transaction/transaction.service.test.ts
+++ b/server/src/domain/transaction/transaction.service.test.ts
@@ -19,7 +19,7 @@ describe('TransactionService Tests', () => {
     await TestSeeder.up({
       connection,
       numOfUsers: 1,
-      numOfTransactionsPerUser: 50,
+      numOfTransactionsPerMonth: 50,
       startDate: new Date('2020-10-01'),
       endDate: new Date('2020-10-31'),
     });

--- a/server/src/domain/transaction/transaction.service.ts
+++ b/server/src/domain/transaction/transaction.service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import TranscationEntity from '@/entity/transaction.entity';
-import { Repository, Between } from 'typeorm';
+import TransactionRepository from '@/domain/transaction/transaction.repository';
+import { Between } from 'typeorm';
 import { BAD_REQUEST, DATABASE_ERROR } from '@/common/error';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
 import {
@@ -10,9 +11,9 @@ import {
 } from './types';
 
 export default class TransactionService {
-  private transactionRepository: Repository<TranscationEntity>;
+  private transactionRepository: TransactionRepository;
 
-  constructor(transactionRepository: Repository<TranscationEntity>) {
+  constructor(transactionRepository: TransactionRepository) {
     this.transactionRepository = transactionRepository;
   }
 

--- a/server/src/lib/date-utils/date-utils.test.ts
+++ b/server/src/lib/date-utils/date-utils.test.ts
@@ -1,0 +1,20 @@
+import DateUtils from '.';
+
+describe('DateUtils Tests', () => {
+  describe('countMonthBetween() Tests', () => {
+    it('2020-01과 2020-12 사이의 month 개수는 12이다.(1월, 12월포함)', () => {
+      const count = DateUtils.countMonthBetween(new Date('2020-01'), new Date('2020-12'));
+      expect(count).toEqual(12);
+    });
+
+    it('2018-06과 2020-12 사이의 month 개수는 31이다.(6월, 12월포함)', () => {
+      const count = DateUtils.countMonthBetween(new Date('2018-06'), new Date('2020-12'));
+      expect(count).toEqual(31);
+    });
+
+    it('2020-12과 2020-12 사이의 month 개수는 1이다.', () => {
+      const count = DateUtils.countMonthBetween(new Date('2020-12'), new Date('2020-12'));
+      expect(count).toEqual(1);
+    });
+  });
+});

--- a/server/src/lib/date-utils/date-utils.test.ts
+++ b/server/src/lib/date-utils/date-utils.test.ts
@@ -17,4 +17,18 @@ describe('DateUtils Tests', () => {
       expect(count).toEqual(1);
     });
   });
+
+  describe('getStartDateAndEndDate() Tests', () => {
+    it('year=2020, month=12일때 startDate=2020-12-01, endDate=2020-12-31이다.', () => {
+      const { startDate, endDate } = DateUtils.getStartDateAndEndDate(2020, 12);
+      expect(DateUtils.dateToString(startDate)).toEqual('2020-12-01');
+      expect(DateUtils.dateToString(endDate)).toEqual('2020-12-31');
+    });
+
+    it('year=2020, month=1일때 startDate=2020-01-01, endDate=2020-01-31이다.', () => {
+      const { startDate, endDate } = DateUtils.getStartDateAndEndDate(2020, 1);
+      expect(DateUtils.dateToString(startDate)).toEqual('2020-01-01');
+      expect(DateUtils.dateToString(endDate)).toEqual('2020-01-31');
+    });
+  });
 });

--- a/server/src/lib/date-utils/index.ts
+++ b/server/src/lib/date-utils/index.ts
@@ -1,0 +1,17 @@
+const dateToString = (date: Date): string => {
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+};
+
+const countMonthBetween = (startDate: Date, endDate: Date): number => {
+  const startYear = startDate.getFullYear();
+  const startMonth = startDate.getMonth();
+  const endYear = endDate.getFullYear();
+  const endMonth = endDate.getMonth();
+  const yearDiff = Math.abs(startYear - endYear);
+  const monthDiff = Math.abs(startMonth - endMonth) + 1;
+  return yearDiff * 12 + monthDiff;
+};
+
+export default { dateToString, countMonthBetween };

--- a/server/src/lib/date-utils/index.ts
+++ b/server/src/lib/date-utils/index.ts
@@ -14,4 +14,13 @@ const countMonthBetween = (startDate: Date, endDate: Date): number => {
   return yearDiff * 12 + monthDiff;
 };
 
-export default { dateToString, countMonthBetween };
+const getStartDateAndEndDate = (
+  year: number,
+  month: number,
+): { startDate: Date; endDate: Date } => {
+  const startDate = new Date(year, month - 1, 1);
+  const endDate = new Date(year, month, 0);
+  return { startDate, endDate };
+};
+
+export default { dateToString, countMonthBetween, getStartDateAndEndDate };

--- a/server/src/lib/dateUtils.ts
+++ b/server/src/lib/dateUtils.ts
@@ -1,7 +1,0 @@
-const dateToString = (date: Date): string => {
-  return `${date.getFullYear()}-${(date.getMonth() + 1)
-    .toString()
-    .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
-};
-
-export default dateToString;

--- a/server/src/seed/seed-generator.ts
+++ b/server/src/seed/seed-generator.ts
@@ -1,10 +1,11 @@
-import UserEntity from '@entity/user.entity';
-import CategoryEntity from '@entity/category.entity';
-import PaymentEntity from '@entity/payment.entity';
-import TransactionEntity from '@entity/transaction.entity';
+import UserEntity from '@/entity/user.entity';
+import CategoryEntity from '@/entity/category.entity';
+import PaymentEntity from '@/entity/payment.entity';
+import TransactionEntity from '@/entity/transaction.entity';
+import DateUtils from '@/lib/date-utils';
 
 const MIN_AMOUNT = 1000;
-const MAX_AMOUNT = 10000;
+const MAX_AMOUNT = 100000;
 
 const generateRandomDate = (start: Date, end: Date): Date => {
   return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
@@ -24,55 +25,80 @@ const generateCategories = (user: UserEntity) => {
 const generatePayments = (user: UserEntity) => {
   const payments = [
     new PaymentEntity({ name: '신한은행', user }),
-    new PaymentEntity({ name: '국민은행', user }),
-    new PaymentEntity({ name: '농협은행', user }),
+    new PaymentEntity({ name: '신한카드', user }),
+    new PaymentEntity({ name: 'KB국민카드', user }),
   ];
   return payments;
 };
 
 const generateTransactions = ({
-  category,
+  categories,
   user,
-  payment,
-  numOfTransactionsPerUser,
+  payments,
+  numOfTransactionsPerMonth,
   startDate,
   endDate,
 }: {
-  category: CategoryEntity;
+  categories: CategoryEntity[];
+  payments: PaymentEntity[];
   user: UserEntity;
-  payment: PaymentEntity;
-  numOfTransactionsPerUser: number;
+  numOfTransactionsPerMonth: number;
   startDate: Date;
   endDate: Date;
 }) => {
   const transactions = [];
-  for (let i = 0; i < numOfTransactionsPerUser; i += 1) {
-    const amount = Math.floor(Math.random() * (MAX_AMOUNT - MIN_AMOUNT) + MIN_AMOUNT);
-    const description = `${user.name}의 가계부내역 ${i + 1}`;
-    const tradeAt = generateRandomDate(startDate, endDate);
-    const isIncome = Math.floor(Math.random() * 2) === 1;
-    const transaction = new TransactionEntity({
-      amount,
-      description,
-      tradeAt,
-      isIncome,
-      category,
-      user,
-      payment,
-    });
-    transactions.push(transaction);
+  const date = new Date(startDate);
+  const endDateTime = endDate.getTime();
+  while (date.getTime() <= endDateTime) {
+    const {
+      startDate: startDateOfMonth,
+      endDate: endDateOfMonth,
+    } = DateUtils.getStartDateAndEndDate(date.getFullYear(), date.getMonth() + 1);
+
+    transactions.push(
+      new TransactionEntity({
+        amount: 3000000,
+        description: '월급',
+        tradeAt: new Date(date.setDate(25)),
+        isIncome: true,
+        category: categories[0],
+        user,
+        payment: payments[0],
+      }),
+    );
+
+    for (let i = 0; i < numOfTransactionsPerMonth - 1; i += 1) {
+      const category = categories[Math.floor(Math.random() * (categories.length - 1)) + 1];
+      const payment = payments[Math.floor(Math.random() * payments.length)];
+      const amount = Math.floor(Math.random() * (MAX_AMOUNT - MIN_AMOUNT) + MIN_AMOUNT);
+      const description = `${user.name}의 가계부내역 ${i + 1}`;
+      const tradeAt = generateRandomDate(startDateOfMonth, endDateOfMonth);
+      const isIncome = false;
+      const transaction = new TransactionEntity({
+        amount,
+        description,
+        tradeAt,
+        isIncome,
+        category,
+        user,
+        payment,
+      });
+      transactions.push(transaction);
+    }
+    date.setMonth(date.getMonth() + 1);
+    date.setDate(1);
   }
   return transactions;
 };
 
 const generateSeedData = ({
   numOfUsers,
-  numOfTransactionsPerUser,
+  numOfTransactionsPerMonth,
   startDate,
   endDate,
 }: {
   numOfUsers: number;
-  numOfTransactionsPerUser: number;
+  numOfTransactionsPerMonth: number;
   startDate: Date;
   endDate: Date;
 }): {
@@ -96,14 +122,12 @@ const generateSeedData = ({
     users.push(user);
     categories.push(...generateCategories(user));
     payments.push(...generatePayments(user));
-    const category = categories[Math.floor(Math.random() * categories.length)];
-    const payment = payments[Math.floor(Math.random() * payments.length)];
     transactions.push(
       ...generateTransactions({
-        category,
+        categories,
+        payments,
         user,
-        payment,
-        numOfTransactionsPerUser,
+        numOfTransactionsPerMonth,
         startDate,
         endDate,
       }),

--- a/server/src/seed/test.seed.ts
+++ b/server/src/seed/test.seed.ts
@@ -9,13 +9,13 @@ import SeedGenerator from './seed-generator';
 const up = async ({
   connection,
   numOfUsers,
-  numOfTransactionsPerUser,
+  numOfTransactionsPerMonth,
   startDate,
   endDate,
 }: {
   connection: Connection;
   numOfUsers: number;
-  numOfTransactionsPerUser: number;
+  numOfTransactionsPerMonth: number;
   startDate: Date;
   endDate: Date;
 }): Promise<void> => {
@@ -25,7 +25,7 @@ const up = async ({
   try {
     const { users, categories, payments, transactions } = SeedGenerator.generateSeedData({
       numOfUsers,
-      numOfTransactionsPerUser,
+      numOfTransactionsPerMonth,
       startDate,
       endDate,
     });

--- a/server/src/seed/up.ts
+++ b/server/src/seed/up.ts
@@ -10,7 +10,7 @@ const up = async () => {
   try {
     const { users, categories, payments, transactions } = SeedGenerator.generateSeedData({
       numOfUsers: 2500,
-      numOfTransactionsPerUser: 400,
+      numOfTransactionsPerMonth: 40,
       startDate: new Date('2020-01-01'),
       endDate: new Date(),
     });
@@ -27,6 +27,7 @@ const up = async () => {
     await queryRunner.commitTransaction();
     console.log('Seed finished');
   } catch (err) {
+    console.log(err);
     await queryRunner.rollbackTransaction();
   } finally {
     await queryRunner.release();

--- a/server/src/setupTests.ts
+++ b/server/src/setupTests.ts
@@ -1,0 +1,12 @@
+import createDBConnection from '@/loader/database';
+import { Connection } from 'typeorm';
+
+let connection: Connection;
+
+beforeAll(async () => {
+  connection = await createDBConnection();
+});
+
+afterAll(async () => {
+  await connection.close();
+});


### PR DESCRIPTION
### Issue Number

Close #153 

### 변경사항
- 가장 소비가 많은 카테고리 정보를 가져오는 API
  - 현재 달이 아닌 요청된 달의 데이터를 반환하도록 수정했습니다.
  - 소비에 대한 집계로 필터링 되지 않던 문제를 수정했습니다.
- TransactionRepository를 CustomRepository로 변경하고 금액을 합산하여 반환하는 로직을 추가했습니다.
- Seeder 모듈 개선
  - 랜덤한 날짜에 데이터를 생성하는 경우 원하는 월에 데이터가 생성되지 않을 수 있는 가능성이 있습니다. 그래서 테스트 코드의 성공 여부가 해당 가능성에 의존하게 되는 문제가 있어서 더미 데이터를 생성할때 모든 월에 데이터가 생성되도록 수정했습니다.

### 새로운 기능

- 사용자의 소비 습관(과소비 지수)을 계산하는 API를 구현했습니다.

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
