### PR TITLE
대시보드 레이아웃, 모달버튼 수정

### DIFF
--- a/client/src/components/common/buttons/ModalToggleButton/styles.tsx
+++ b/client/src/components/common/buttons/ModalToggleButton/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const ModalButton = styled.button`
   display: flex;
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 3rem;
   right: 1.5rem;
   width: 3rem;
   height: 3rem;
@@ -13,6 +13,11 @@ export const ModalButton = styled.button`
   border: none;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.36);
   z-index: 100;
+  background: #0e7ee0;
+
+  @media (min-width: 992px) {
+    right: calc((100% - 930px) / 2);
+  }
 `;
 
 export const ModalButtonContent = styled.div`
@@ -22,5 +27,5 @@ export const ModalButtonContent = styled.div`
   font-size: 2rem;
   align-items: center;
   justify-content: center;
-  color: #0e7ee0;
+  color: #fff;
 `;

--- a/client/src/container/DashboardContainer/index.tsx
+++ b/client/src/container/DashboardContainer/index.tsx
@@ -57,7 +57,7 @@ const DashboardContainer = (): JSX.Element => {
         return '이 좋지 않네요 😢';
       }
       if (overspendingIndex >= 0.5) {
-        return '은 나쁘지 않아요 🙂';
+        return '이 좋습니다 🙂';
       }
       return '이 훌륭하네요 😍';
     },
@@ -73,7 +73,7 @@ const DashboardContainer = (): JSX.Element => {
         <S.BoxHeader>
           <S.BoxTitle>{datePicker.month}월 소비/수입</S.BoxTitle>
           <S.SpendingStatusDescription>
-            이번달 소비 습관{getSpendingStatus(overspendingIndexState.overspendingIndex)}
+            소비 습관{getSpendingStatus(overspendingIndexState.overspendingIndex)}
           </S.SpendingStatusDescription>
         </S.BoxHeader>
         <S.BoxRow>
@@ -102,8 +102,8 @@ const DashboardContainer = (): JSX.Element => {
         </S.BoxHeader>
         <S.BoxRow>{mostSpendingCategoryState.name}에 가장 많은 돈을 쓰셨어요</S.BoxRow>
         <S.BoxRow>
-          사용한 금액 : {NumberUtils.numberWithCommas(Number(mostSpendingCategoryState.aggregate))}
-          원
+          사용한 금액 :{' '}
+          {NumberUtils.numberWithCommas(Number(mostSpendingCategoryState.aggregate || 0))}원
         </S.BoxRow>
       </S.Box>
       <S.Box>


### PR DESCRIPTION
### 변경사항

- 대시보드의 소비습관 메세지 레이아웃이 틀어지는 문제 수정함.
  - 소비습관이 나쁘지 않아요 -> 소비습관이 좋습니다
  - '이번달' 삭제

- 모달버튼 색감 변경, 위치 수정(반응형)

### 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
