### PR TITLE
4주차 버그수정 & 리팩토링 진행

### DIFF
--- a/client/src/components/aggregateCategory/Item/styles.tsx
+++ b/client/src/components/aggregateCategory/Item/styles.tsx
@@ -24,6 +24,9 @@ export const InfoBox = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.8rem;
+  svg {
+    cursor: pointer;
+  }
 `;
 export const DetailBox = styled.div`
   display: ${(props) => props.style?.display};

--- a/client/src/components/common/buttons/ModalToggleButton/styles.tsx
+++ b/client/src/components/common/buttons/ModalToggleButton/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const ModalButton = styled.button`
   display: flex;
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 3rem;
   right: 1.5rem;
   width: 3rem;
   height: 3rem;
@@ -13,6 +13,11 @@ export const ModalButton = styled.button`
   border: none;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.36);
   z-index: 100;
+  background: #0e7ee0;
+
+  @media (min-width: 992px) {
+    right: calc((100% - 930px) / 2);
+  }
 `;
 
 export const ModalButtonContent = styled.div`
@@ -22,5 +27,5 @@ export const ModalButtonContent = styled.div`
   font-size: 2rem;
   align-items: center;
   justify-content: center;
-  color: #0e7ee0;
+  color: #fff;
 `;

--- a/client/src/components/transaction/EmptyState/index.tsx
+++ b/client/src/components/transaction/EmptyState/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import StyledEmptyState from './styles';
+import { EmptyStateComponentProps } from './types';
+
+const EmptyStateComponent = ({ align = 'center' }: EmptyStateComponentProps): JSX.Element => {
+  return <StyledEmptyState align={align}>내역이 없습니다</StyledEmptyState>;
+};
+
+export default EmptyStateComponent;

--- a/client/src/components/transaction/EmptyState/styles.ts
+++ b/client/src/components/transaction/EmptyState/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import { EmptyStateComponentProps } from './types';
+
+const StyledEmptyState = styled.div<EmptyStateComponentProps>`
+  padding-top: 0.5rem;
+  text-align: ${(props) => props.align};
+`;
+
+export default StyledEmptyState;

--- a/client/src/components/transaction/EmptyState/types.ts
+++ b/client/src/components/transaction/EmptyState/types.ts
@@ -1,0 +1,3 @@
+export type EmptyStateComponentProps = {
+  align?: 'left' | 'center';
+};

--- a/client/src/container/DashboardContainer/index.tsx
+++ b/client/src/container/DashboardContainer/index.tsx
@@ -9,6 +9,7 @@ import AmountText from '@/components/transaction/AmountText';
 import FixedExpenditure from '@container/FixedExpenditure';
 import aggregateAPI from '@/libs/api/aggregate';
 import NumberUtils from '@/libs/numberUtils';
+import EmptyStateComponent from '@/components/transaction/EmptyState';
 import * as S from './styles';
 
 const RECENT_TRANSACTION_LIMIT = 3;
@@ -57,7 +58,7 @@ const DashboardContainer = (): JSX.Element => {
         return '이 좋지 않네요 😢';
       }
       if (overspendingIndex >= 0.5) {
-        return '은 나쁘지 않아요 🙂';
+        return '이 좋습니다 🙂';
       }
       return '이 훌륭하네요 😍';
     },
@@ -73,7 +74,7 @@ const DashboardContainer = (): JSX.Element => {
         <S.BoxHeader>
           <S.BoxTitle>{datePicker.month}월 소비/수입</S.BoxTitle>
           <S.SpendingStatusDescription>
-            이번달 소비 습관{getSpendingStatus(overspendingIndexState.overspendingIndex)}
+            소비 습관{getSpendingStatus(overspendingIndexState.overspendingIndex)}
           </S.SpendingStatusDescription>
         </S.BoxHeader>
         <S.BoxRow>
@@ -88,11 +89,15 @@ const DashboardContainer = (): JSX.Element => {
           <S.BoxTitle>최근 내역</S.BoxTitle>
           <Link to="/calendar">자세히 보기</Link>
         </S.BoxHeader>
-        {transactionState.transactions.slice(0, RECENT_TRANSACTION_LIMIT).map((transaction) => (
-          <S.RecentTransactionBoxItem key={`transaction${transaction.tid}`}>
-            <TransactionListItem transaction={transaction} />
-          </S.RecentTransactionBoxItem>
-        ))}
+        {transactionState.transactions.length !== 0 ? (
+          transactionState.transactions.slice(0, RECENT_TRANSACTION_LIMIT).map((transaction) => (
+            <S.RecentTransactionBoxItem key={`transaction${transaction.tid}`}>
+              <TransactionListItem transaction={transaction} />
+            </S.RecentTransactionBoxItem>
+          ))
+        ) : (
+          <EmptyStateComponent align="left" />
+        )}
       </S.Box>
       <FixedExpenditure />
       <S.Box>
@@ -102,8 +107,8 @@ const DashboardContainer = (): JSX.Element => {
         </S.BoxHeader>
         <S.BoxRow>{mostSpendingCategoryState.name}에 가장 많은 돈을 쓰셨어요</S.BoxRow>
         <S.BoxRow>
-          사용한 금액 : {NumberUtils.numberWithCommas(Number(mostSpendingCategoryState.aggregate))}
-          원
+          사용한 금액 :{' '}
+          {NumberUtils.numberWithCommas(Number(mostSpendingCategoryState.aggregate || 0))}원
         </S.BoxRow>
       </S.Box>
       <S.Box>

--- a/client/src/container/DetailedFixedExpenditure/index.tsx
+++ b/client/src/container/DetailedFixedExpenditure/index.tsx
@@ -51,34 +51,36 @@ const DetailedFixedExpenditure = (): JSX.Element => {
         <S.Amount>총 {getAmount('both')} 원</S.Amount>
       </S.Box>
       {fixedExpenditure.data.paid.length !== 0 ? (
-        <>
-          <S.Box>
-            <S.Category color="#E73636">지출 완료</S.Category>
-            {fixedExpenditure.data.paid.map((fixedItem) => (
-              <S.ItemBox key={`fixed${fixedItem.fid}`}>
-                <FixedExpenditureItem fixedItem={fixedItem} isPaid />
-              </S.ItemBox>
-            ))}
-            <S.AmountBox>
-              <p>지출 완료 합계</p>
-              <p>{getAmount('paid')}원</p>
-            </S.AmountBox>
-          </S.Box>
-          <S.Box>
-            <S.Category color="#0e7ee0">지출 예정</S.Category>
-            {fixedExpenditure.data.estimated.map((fixedItem) => (
-              <S.ItemBox key={`fixed${fixedItem.fid}`}>
-                <FixedExpenditureItem fixedItem={fixedItem} isPaid={false} />
-              </S.ItemBox>
-            ))}
-            <S.AmountBox>
-              <p>지출 예정 합계</p>
-              <p>{getAmount('estimated')}원</p>
-            </S.AmountBox>
-          </S.Box>
-        </>
+        <S.Box>
+          <S.Category color="#E73636">지출 완료</S.Category>
+          {fixedExpenditure.data.paid.map((fixedItem) => (
+            <S.ItemBox key={`fixed${fixedItem.fid}`}>
+              <FixedExpenditureItem fixedItem={fixedItem} isPaid />
+            </S.ItemBox>
+          ))}
+          <S.AmountBox>
+            <p>지출 완료 합계</p>
+            <p>{getAmount('paid')}원</p>
+          </S.AmountBox>
+        </S.Box>
       ) : (
-        <div />
+        <></>
+      )}
+      {fixedExpenditure.data.estimated.length !== 0 ? (
+        <S.Box>
+          <S.Category color="#0e7ee0">지출 예정</S.Category>
+          {fixedExpenditure.data.estimated.map((fixedItem) => (
+            <S.ItemBox key={`fixed${fixedItem.fid}`}>
+              <FixedExpenditureItem fixedItem={fixedItem} isPaid={false} />
+            </S.ItemBox>
+          ))}
+          <S.AmountBox>
+            <p>지출 예정 합계</p>
+            <p>{getAmount('estimated')}원</p>
+          </S.AmountBox>
+        </S.Box>
+      ) : (
+        <></>
       )}
     </>
   );

--- a/client/src/container/SelectMonth/index.tsx
+++ b/client/src/container/SelectMonth/index.tsx
@@ -36,7 +36,7 @@ export default function SelectMonth(): JSX.Element {
     <>
       <S.MonthDiv>
         <S.ArrowDiv onClick={() => onChangeLeftMonth()}>{'<'}</S.ArrowDiv>
-        {`${datePicker.year}-${datePicker.month}`}
+        <S.MonthText>{`${datePicker.year}-${datePicker.month}`}</S.MonthText>
         <S.ArrowDiv onClick={() => onChangeRightMonth()}>{'>'}</S.ArrowDiv>
       </S.MonthDiv>
     </>

--- a/client/src/container/SelectMonth/styles.tsx
+++ b/client/src/container/SelectMonth/styles.tsx
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
 
-const MonthDiv = styled.div`
+export const MonthDiv = styled.div`
   display: inline-flex;
   width: 100%;
-  justify-content: center;
-  cursor: pointer;
-  margin: 10px 0px 0px 0px;
+  justify-content: start;
   font-size: 1.5rem;
   margin-bottom: 10px;
 `;
 
-const ArrowDiv = styled.div`
-  margin: 0px 10px;
+export const ArrowDiv = styled.div`
+  cursor: pointer;
 `;
-export { ArrowDiv, MonthDiv };
+
+export const MonthText = styled.p`
+  margin: 0 0.3rem 0 0.3rem;
+`;

--- a/client/src/container/TransactionList/index.tsx
+++ b/client/src/container/TransactionList/index.tsx
@@ -4,6 +4,7 @@ import TransactionListItem from '@/components/transaction/ListItem';
 import { RootState } from '@modules/index';
 import { toggleModalOn } from '@/modules/updateModal';
 import { TransactionModel } from '@/commons/types/transaction';
+import EmptyStateComponent from '@/components/transaction/EmptyState';
 import * as S from './styles';
 import { TransactionListContainerProps } from './types';
 
@@ -19,23 +20,27 @@ const TransactionListContainer = ({ editable }: TransactionListContainerProps): 
 
   return (
     <>
-      {transaction.transactionDetailsByDate.map(([date, transactionDetails]) => (
-        <S.DateContainer key={`transaction_box_${date}`}>
-          <S.DateLabel>{date}일</S.DateLabel>
-          {transactionDetails.map((transactionDetail) => (
-            <S.TransactionListItemWrapper>
-              <TransactionListItem
-                toggleUpdateModal={() => {
-                  toggleModal(transactionDetail);
-                }}
-                key={`transaction_${transactionDetail.tid}`}
-                transaction={transactionDetail}
-                editable={editable}
-              />
-            </S.TransactionListItemWrapper>
-          ))}
-        </S.DateContainer>
-      ))}
+      {transaction.transactionDetailsByDate.length !== 0 ? (
+        transaction.transactionDetailsByDate.map(([date, transactionDetails]) => (
+          <S.DateContainer key={`transaction_box_${date}`}>
+            <S.DateLabel>{date}일</S.DateLabel>
+            {transactionDetails.map((transactionDetail) => (
+              <S.TransactionListItemWrapper>
+                <TransactionListItem
+                  toggleUpdateModal={() => {
+                    toggleModal(transactionDetail);
+                  }}
+                  key={`transaction_${transactionDetail.tid}`}
+                  transaction={transactionDetail}
+                  editable={editable}
+                />
+              </S.TransactionListItemWrapper>
+            ))}
+          </S.DateContainer>
+        ))
+      ) : (
+        <EmptyStateComponent />
+      )}
     </>
   );
 };

--- a/client/src/container/TransactionSelectList/index.tsx
+++ b/client/src/container/TransactionSelectList/index.tsx
@@ -3,26 +3,33 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/modules/index';
 import TransactionListItem from '@/components/transaction/ListItem';
 import { TransactionListItemWrapper } from '@/container/TransactionList/styles';
+import { TransactionModel } from '@/commons/types/transaction';
+import EmptyStateComponent from '@/components/transaction/EmptyState';
 import * as S from './styles';
 
 const TransactionSelectList = (): JSX.Element => {
   const { transaction, calendarDaySelector } = useSelector((state: RootState) => state);
   const transactionData = new Map(transaction.transactionDetailsByDate);
-  const transactionList = transactionData
-    .get(Number(calendarDaySelector.day))
-    ?.map((transactionDay) => (
-      <TransactionListItemWrapper>
-        <TransactionListItem
-          key={`transaction_${transactionDay.tid}`}
-          transaction={transactionDay}
-        />
-      </TransactionListItemWrapper>
-    ));
+  const transactionList = transactionData.get(
+    Number(calendarDaySelector.day),
+  ) as TransactionModel[];
+
   return (
     <>
       <S.DateContainer>
         <S.DateLabel>{calendarDaySelector.day}일</S.DateLabel>
-        {transactionList}
+        {transactionList ? (
+          transactionList.map((transactionDay) => (
+            <TransactionListItemWrapper>
+              <TransactionListItem
+                key={`transaction_${transactionDay.tid}`}
+                transaction={transactionDay}
+              />
+            </TransactionListItemWrapper>
+          ))
+        ) : (
+          <EmptyStateComponent />
+        )}
       </S.DateContainer>
     </>
   );

--- a/client/src/views/CalendarPage/index.tsx
+++ b/client/src/views/CalendarPage/index.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import MainLayout from '@/components/common/layouts/MainLayout';
 import Calendar from '@container/Calendar';
 import TransactionUpdateModal from '@/container/TransactionUpdateModal';
+import TransactionModal from '@container/TransactionModal';
+import ModalToggleButton from '@components/common/buttons/ModalToggleButton';
 
 const CalendarPage = (): JSX.Element => {
+  const [showModal, setShowModal] = useState(false);
+  const toggleModal = useCallback(() => setShowModal(!showModal), [showModal]);
   return (
     <MainLayout>
       <Calendar />
+      <ModalToggleButton setToggle={toggleModal} />
+      <TransactionModal show={showModal} toggleModal={toggleModal} />
       <TransactionUpdateModal />
     </MainLayout>
   );


### PR DESCRIPTION
### 변경사항

1. 대시보드 소비습관 메세지 위치 조절 (모바일 환경에서) - 이번달 삭제

2. 카테고리 통계 없을때 NaN으로 표시되는거 수정

3. 캘린더 페이지 모달 추가

4. 리스트 없을때 "내역이 없습니다." 표시

   - 최근내역 
   - 캘린더 리스트 
   - 고정지출 없을때 

5. 모달 버튼 위치 조금 위로 

6. 대시보드 월 선택 컴포넌트 위치 
7. 모달 버튼 색감 변경

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
