### PR TITLE
카테고리 통계, 라인 차트 페이지 추가 작업, 컴포넌트 화살표 함수로 변경

### DIFF
--- a/client/src/components/aggregateCategory/Main/index.tsx
+++ b/client/src/components/aggregateCategory/Main/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import AggregateCategoryItem from '@/components/aggregateCategory/Item';
 import { AggregateCategoryPropType } from '@/commons/types/aggregateCategory';
 import { Doughnut } from 'react-chartjs-2';
+import EmptyStateComponent from '@/components/transaction/EmptyState';
 import * as S from './styles';
 
 const AggregateCategoryMain = ({ list, isIncome }: AggregateCategoryPropType): JSX.Element => {
@@ -32,32 +33,44 @@ const AggregateCategoryMain = ({ list, isIncome }: AggregateCategoryPropType): J
   }, [list, isIncome]);
   return (
     <>
-      <S.Chart>
-        <Doughnut
-          data={state}
-          options={{
-            width: '400',
-            height: '400',
-            responsive: true,
-            maintainAspectRatio: true,
-            legend: {
-              display: true,
-              position: 'right',
-              labels: { fontSize: 14, boxWidth: 14 },
-            },
-          }}
-        />
-      </S.Chart>
-      <S.Box>
-        {isIncome ? <S.Title>카테고리별 수입</S.Title> : <S.Title>카테고리별 지출</S.Title>}
-        {list.length !== 0 ? (
-          list.map((item) => (
-            <AggregateCategoryItem key={item.category + item.aggregate} item={item} total={total} />
-          ))
-        ) : (
-          <></>
-        )}
-      </S.Box>
+      {list.length === 0 ? (
+        <S.EmptyStateBox>
+          <EmptyStateComponent />
+        </S.EmptyStateBox>
+      ) : (
+        <>
+          <S.Chart>
+            <Doughnut
+              data={state}
+              options={{
+                width: '400',
+                height: '400',
+                responsive: true,
+                maintainAspectRatio: true,
+                legend: {
+                  display: true,
+                  position: 'right',
+                  labels: { fontSize: 14, boxWidth: 14 },
+                },
+              }}
+            />
+          </S.Chart>
+          <S.Box>
+            {isIncome ? <S.Title>카테고리별 수입</S.Title> : <S.Title>카테고리별 지출</S.Title>}
+            {list.length !== 0 ? (
+              list.map((item) => (
+                <AggregateCategoryItem
+                  key={item.category + item.aggregate}
+                  item={item}
+                  total={total}
+                />
+              ))
+            ) : (
+              <></>
+            )}
+          </S.Box>
+        </>
+      )}
     </>
   );
 };

--- a/client/src/components/aggregateCategory/Main/styles.tsx
+++ b/client/src/components/aggregateCategory/Main/styles.tsx
@@ -23,3 +23,7 @@ export const Chart = styled.div`
   margin: 1.4rem 0 1.4rem 0;
   box-sizing: border-box;
 `;
+
+export const EmptyStateBox = styled.div`
+  margin-top: 2rem;
+`;

--- a/client/src/components/calendar/CalendarView/index.tsx
+++ b/client/src/components/calendar/CalendarView/index.tsx
@@ -5,16 +5,14 @@ import getDayMatrix from '@libs/calendarUtils';
 import { getWeekDays } from '@libs/nationalCalendarUtils';
 import { CalendarViewType } from './types';
 
-function CalendarView({ totalInOut, lang, year, month }: CalendarViewType): JSX.Element {
+const CalendarView = ({ totalInOut, lang, year, month }: CalendarViewType): JSX.Element => {
   return (
-    <>
-      <MatrixView
-        headers={getWeekDays(lang)}
-        matrix={getDayMatrix(year, month)}
-        cell={(date, key) => <TableCell day={date} key={`table${key}`} totalInOut={totalInOut} />}
-      />
-    </>
+    <MatrixView
+      headers={getWeekDays(lang)}
+      matrix={getDayMatrix(year, month)}
+      cell={(date, key) => <TableCell day={date} key={`table${key}`} totalInOut={totalInOut} />}
+    />
   );
-}
+};
 
 export default CalendarView;

--- a/client/src/components/calendar/MatrixView/index.tsx
+++ b/client/src/components/calendar/MatrixView/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MatrixViewTypes } from './types';
 import * as S from './styles';
 
-function MatrixView({ matrix, headers, cell }: MatrixViewTypes): JSX.Element {
+const MatrixView = ({ matrix, headers, cell }: MatrixViewTypes): JSX.Element => {
   return (
     <S.Matrix>
       <S.Table>
@@ -23,6 +23,6 @@ function MatrixView({ matrix, headers, cell }: MatrixViewTypes): JSX.Element {
       </S.Table>
     </S.Matrix>
   );
-}
+};
 
 export default MatrixView;

--- a/client/src/components/calendar/TableCell/index.tsx
+++ b/client/src/components/calendar/TableCell/index.tsx
@@ -14,10 +14,10 @@ const getRem = (n: number): string => {
   return rem;
 };
 
-function TableCell({ day, totalInOut }: TableCellTypes): JSX.Element {
+const TableCell = ({ day, totalInOut }: TableCellTypes): JSX.Element => {
   const { calendarDaySelector } = useSelector((state: RootState) => state);
   const isBold = (): 'isBold' | '' => {
-    if (Number(calendarDaySelector.day) === Number(day) && day !== ' ') return 'isBold';
+    if (Number(calendarDaySelector.day) === Number(day)) return 'isBold';
     return '';
   };
   const dispatch = useDispatch();
@@ -63,6 +63,6 @@ function TableCell({ day, totalInOut }: TableCellTypes): JSX.Element {
       </S.CellButton>
     </>
   );
-}
+};
 
 export default TableCell;

--- a/client/src/components/common/ArrowIcon/index.tsx
+++ b/client/src/components/common/ArrowIcon/index.tsx
@@ -3,12 +3,12 @@ import ArrowSVG from '@/assets/svg/Arrow.svg';
 import StyledArrow from './styles';
 import { ArrowPropType } from './types';
 
-function ArrowIcon({ height, width, rotate }: ArrowPropType): JSX.Element {
+const ArrowIcon = ({ height, width, rotate }: ArrowPropType): JSX.Element => {
   return (
     <StyledArrow height={height} width={width} rotate={rotate}>
       <img src={ArrowSVG} alt="arrow" />
     </StyledArrow>
   );
-}
+};
 
 export default ArrowIcon;

--- a/client/src/components/common/Dropdown/index.tsx
+++ b/client/src/components/common/Dropdown/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { DropdownType } from './types';
 import * as S from './styles';
 
-export default function Dropdown({ icon, isRight, children }: DropdownType): JSX.Element {
+const Dropdown = ({ icon, isRight, children }: DropdownType): JSX.Element => {
   const [isShow, setDisplay] = useState(false);
   const position = isRight ? 'right' : '';
 
@@ -22,4 +22,6 @@ export default function Dropdown({ icon, isRight, children }: DropdownType): JSX
       )}
     </>
   );
-}
+};
+
+export default Dropdown;

--- a/client/src/components/common/Logo/index.tsx
+++ b/client/src/components/common/Logo/index.tsx
@@ -3,12 +3,12 @@ import LogoSVG from '@/assets/svg/Logo.svg';
 import { LogoPropType } from './types';
 import StyledLogo from './styles';
 
-function Logo({ height }: LogoPropType): JSX.Element {
+const Logo = ({ height }: LogoPropType): JSX.Element => {
   return (
     <StyledLogo height={height}>
       <img src={LogoSVG} alt="logo" />
     </StyledLogo>
   );
-}
+};
 
 export default Logo;

--- a/client/src/components/common/Modal/index.tsx
+++ b/client/src/components/common/Modal/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as S from './styles';
 import { ModalProps } from './types';
 
-function Modal({ children, show, toggleModal }: ModalProps): JSX.Element {
+const Modal = ({ children, show, toggleModal }: ModalProps): JSX.Element => {
   return (
     <S.Modal show={show} onClick={toggleModal}>
       <S.Container
@@ -12,6 +12,6 @@ function Modal({ children, show, toggleModal }: ModalProps): JSX.Element {
       </S.Container>
     </S.Modal>
   );
-}
+};
 
 export default Modal;

--- a/client/src/components/common/buttons/CustomButton/index.tsx
+++ b/client/src/components/common/buttons/CustomButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as S from './styles';
 import { CustomButtonProps } from './types';
 
-function CustomButton(props: CustomButtonProps): JSX.Element {
+const CustomButton = (props: CustomButtonProps): JSX.Element => {
   const { image, children, color, size, onClickEvent } = props;
 
   return (
@@ -17,6 +17,6 @@ function CustomButton(props: CustomButtonProps): JSX.Element {
       )}
     </S.Button>
   );
-}
+};
 
 export default CustomButton;

--- a/client/src/components/common/buttons/ModalToggleButton/index.tsx
+++ b/client/src/components/common/buttons/ModalToggleButton/index.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import * as S from './styles';
 import { ModalToggleButtonProps } from './types';
 
-function ModalToggleButton({ setToggle }: ModalToggleButtonProps): JSX.Element {
+const ModalToggleButton = ({ setToggle }: ModalToggleButtonProps): JSX.Element => {
   return (
     <S.ModalButton onClick={setToggle}>
       <S.ModalButtonContent>+</S.ModalButtonContent>
     </S.ModalButton>
   );
-}
+};
 
 export default ModalToggleButton;

--- a/client/src/components/common/buttons/OAuthLoginButton/index.tsx
+++ b/client/src/components/common/buttons/OAuthLoginButton/index.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import endpoints from '@/libs/endpoints';
 import LoginButtonResourceFactory from './buttonResourceFactory';
+import { PropsType } from './types';
 
-type PropsType = {
-  provider: 'google' | 'naver' | 'kakao';
-};
-
-function OAuthLoginButton({ provider }: PropsType): JSX.Element {
+const OAuthLoginButton = ({ provider }: PropsType): JSX.Element => {
   const { Button, text } = LoginButtonResourceFactory.getButtonResource(provider);
   const clickHandler = () => {
     window.location.href = `${endpoints.API_BASE_URL}${endpoints.AUTH_API}/${provider}`;
   };
 
   return <Button onClick={clickHandler}>{text}</Button>;
-}
+};
 
 export default OAuthLoginButton;

--- a/client/src/components/common/buttons/OAuthLoginButton/types.ts
+++ b/client/src/components/common/buttons/OAuthLoginButton/types.ts
@@ -1,0 +1,3 @@
+export type PropsType = {
+  provider: 'google' | 'naver' | 'kakao';
+};

--- a/client/src/components/common/forms/CustomSelectInput/index.tsx
+++ b/client/src/components/common/forms/CustomSelectInput/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { SelectInputProps } from './types';
 import * as S from './style';
 
-function CustomSelectInput(props: SelectInputProps): JSX.Element {
+const CustomSelectInput = (props: SelectInputProps): JSX.Element => {
   const { placeholder, children, name, onChange, value } = props;
   const initialValue = value?.id || 0;
   const [inputValue, setInputValue] = useState(initialValue);
@@ -40,6 +40,6 @@ function CustomSelectInput(props: SelectInputProps): JSX.Element {
       ))}
     </S.SelectInput>
   );
-}
+};
 
 export default CustomSelectInput;

--- a/client/src/components/common/layouts/Header/index.tsx
+++ b/client/src/components/common/layouts/Header/index.tsx
@@ -11,7 +11,7 @@ import * as S from './styles';
 const HeaderDropdownIcon = (
   <img src={CircleUserSVG} alt="settings-button" width="24px" height="24px" />
 );
-function Header(): JSX.Element {
+const Header = (): JSX.Element => {
   const list = ['결제수단 관리', '카테고리 관리'];
   const linkPageList = ['manage-payment', 'manage-category'];
   const dropdonwList = list.map((v: string, i: number) => (
@@ -45,6 +45,6 @@ function Header(): JSX.Element {
       </S.HeaderContentDiv>
     </S.HeaderDiv>
   );
-}
+};
 
 export default React.memo(Header);

--- a/client/src/components/transaction/AmountText/index.tsx
+++ b/client/src/components/transaction/AmountText/index.tsx
@@ -3,7 +3,7 @@ import NumberUtils from '@libs/numberUtils';
 import StyledAmountText from './styles';
 import { AmountTextProps } from './types';
 
-function AmountText({ isIncome, size = 'md', amount }: AmountTextProps): JSX.Element {
+const AmountText = ({ isIncome, size = 'md', amount }: AmountTextProps): JSX.Element => {
   return (
     <StyledAmountText isIncome={isIncome} size={size}>
       {isIncome
@@ -11,6 +11,6 @@ function AmountText({ isIncome, size = 'md', amount }: AmountTextProps): JSX.Ele
         : `-${NumberUtils.numberWithCommas(amount)}`}
     </StyledAmountText>
   );
-}
+};
 
 export default AmountText;

--- a/client/src/components/transaction/ModalHeaderText/index.tsx
+++ b/client/src/components/transaction/ModalHeaderText/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { ModalHeaderProps } from './types';
 import ModalHeaderTextStyle from './styles';
 
-function ModalHeaderText({ children }: ModalHeaderProps): JSX.Element {
+const ModalHeaderText = ({ children }: ModalHeaderProps): JSX.Element => {
   return <ModalHeaderTextStyle>{children}</ModalHeaderTextStyle>;
-}
+};
 
 export default ModalHeaderText;

--- a/client/src/components/transaction/ModalRadioButton/index.tsx
+++ b/client/src/components/transaction/ModalRadioButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as S from './styles';
 import { ModalRadioButtonProps } from './types';
 
-function ModalRadioButton({ setIsIncome, onChange, value }: ModalRadioButtonProps): JSX.Element {
+const ModalRadioButton = ({ setIsIncome, onChange, value }: ModalRadioButtonProps): JSX.Element => {
   const onChangeRadioButton = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value: targetValue } = event.target;
     const isIncome = targetValue === 'true';
@@ -37,6 +37,6 @@ function ModalRadioButton({ setIsIncome, onChange, value }: ModalRadioButtonProp
       </S.RadioButtonWrapper>
     </S.RadioButtonContainer>
   );
-}
+};
 
 export default ModalRadioButton;

--- a/client/src/components/transaction/ModalXButton/index.tsx
+++ b/client/src/components/transaction/ModalXButton/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import XButton from './styles';
 import { ModalXButtonProps } from './types';
 
-function ModalXButton({ onClickEvent }: ModalXButtonProps): JSX.Element {
+const ModalXButton = ({ onClickEvent }: ModalXButtonProps): JSX.Element => {
   return <XButton onClick={onClickEvent}>X</XButton>;
-}
+};
 
 export default ModalXButton;

--- a/client/src/container/CategoryManageContainer/index.tsx
+++ b/client/src/container/CategoryManageContainer/index.tsx
@@ -67,17 +67,19 @@ const CategoryManageContainer = ({ isIncome }: CategoryManageContainerProps): JS
           border
         />
       )}
-      <CategoryListContainer>
-        {categoryList.map((category) => (
-          <ManageItem
-            item={category}
-            deleteItem={deleteCategory}
-            updateItem={updateCategory}
-            onChangeInput={onChangeCategoryName}
-            key={`m-category${category.id}`}
-          />
-        ))}
-      </CategoryListContainer>
+      {categoryList.length !== 0 && (
+        <CategoryListContainer>
+          {categoryList.map((category) => (
+            <ManageItem
+              item={category}
+              deleteItem={deleteCategory}
+              updateItem={updateCategory}
+              onChangeInput={onChangeCategoryName}
+              key={`m-category${category.id}`}
+            />
+          ))}
+        </CategoryListContainer>
+      )}
     </>
   );
 };

--- a/client/src/container/DetailedFixedExpenditure/index.tsx
+++ b/client/src/container/DetailedFixedExpenditure/index.tsx
@@ -50,7 +50,7 @@ const DetailedFixedExpenditure = (): JSX.Element => {
         <S.Title>고정적인 지출</S.Title>
         <S.Amount>총 {getAmount('both')} 원</S.Amount>
       </S.Box>
-      {fixedExpenditure.data.paid.length !== 0 ? (
+      {fixedExpenditure.data.paid.length !== 0 && (
         <S.Box>
           <S.Category color="#E73636">지출 완료</S.Category>
           {fixedExpenditure.data.paid.map((fixedItem) => (
@@ -63,10 +63,8 @@ const DetailedFixedExpenditure = (): JSX.Element => {
             <p>{getAmount('paid')}원</p>
           </S.AmountBox>
         </S.Box>
-      ) : (
-        <></>
       )}
-      {fixedExpenditure.data.estimated.length !== 0 ? (
+      {fixedExpenditure.data.estimated.length !== 0 && (
         <S.Box>
           <S.Category color="#0e7ee0">지출 예정</S.Category>
           {fixedExpenditure.data.estimated.map((fixedItem) => (
@@ -79,8 +77,6 @@ const DetailedFixedExpenditure = (): JSX.Element => {
             <p>{getAmount('estimated')}원</p>
           </S.AmountBox>
         </S.Box>
-      ) : (
-        <></>
       )}
     </>
   );

--- a/client/src/container/LineGraphContainer/index.tsx
+++ b/client/src/container/LineGraphContainer/index.tsx
@@ -2,20 +2,25 @@ import LineGraph from '@/components/transaction/LineGraph';
 import { RootState } from '@/modules';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import EmptyStateComponent from '@/components/transaction/EmptyState';
 import SelectMonth from '../SelectMonth';
 import * as S from './styles';
 
-const LineGraphContainer = () => {
+const LineGraphContainer = (): JSX.Element => {
   const { transaction } = useSelector((state: RootState) => state);
   return (
     <>
       {transaction && (
         <>
           <SelectMonth />
-          <S.StyledLineGraphContainer>
-            <S.LineGraphText>기간별 통계</S.LineGraphText>
-            <LineGraph data={transaction.aggregationByDate} />
-          </S.StyledLineGraphContainer>
+          {transaction.aggregationByDate.length === 0 ? (
+            <EmptyStateComponent />
+          ) : (
+            <S.StyledLineGraphContainer>
+              <S.LineGraphText>기간별 통계</S.LineGraphText>
+              <LineGraph data={transaction.aggregationByDate} />
+            </S.StyledLineGraphContainer>
+          )}
         </>
       )}
     </>

--- a/client/src/container/PaymentManageMain/index.tsx
+++ b/client/src/container/PaymentManageMain/index.tsx
@@ -63,17 +63,19 @@ const PaymentManageContainer = (): JSX.Element => {
           border
         />
       )}
-      <S.ManageListContainer>
-        {paymentList.map((payment) => (
-          <ManageItem
-            item={payment}
-            deleteItem={deletePayment}
-            updateItem={updatePayment}
-            onChangeInput={onChangePaymentName}
-            key={`m-payment${payment.id}`}
-          />
-        ))}
-      </S.ManageListContainer>
+      {paymentList.length !== 0 && (
+        <S.ManageListContainer>
+          {paymentList.map((payment) => (
+            <ManageItem
+              item={payment}
+              deleteItem={deletePayment}
+              updateItem={updatePayment}
+              onChangeInput={onChangePaymentName}
+              key={`m-payment${payment.id}`}
+            />
+          ))}
+        </S.ManageListContainer>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Issue Number

Close #184

### 변경사항
- 화살표 함수로 구현되어 있지 않은 컴포넌트 화살표 함수로 변경
- 카테고리, 결제수단 페이지에 데이터가 없을 때 비어있는 박스 보여주지 않게 변경

### 새로운 기능
- 라인 차트, 카테고리 통계 페이지에 데이터 없을 때 내역 없음 표시

![캡처](https://user-images.githubusercontent.com/66261552/101988713-bf034180-3cde-11eb-8291-4667af48057f.PNG)


### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
