### PR TITLE
[fix]파서시 유효성 검시가 되지 않던 오류 수정

### DIFF
--- a/client/src/components/calendar/TableCell/styles.ts
+++ b/client/src/components/calendar/TableCell/styles.ts
@@ -10,10 +10,10 @@ const TotalOut = styled.div`
 `;
 const CellButton = styled.td`
   position: relative;
+  text-align: center;
   &.isCursor {
     cursor: pointer;
   }
-  text-align: center;
   &.isBold {
     font-weight: bold;
     color: #1864ab;

--- a/client/src/components/common/buttons/CustomButton/index.tsx
+++ b/client/src/components/common/buttons/CustomButton/index.tsx
@@ -4,9 +4,9 @@ import { CustomButtonProps } from './types';
 
 const CustomButton = (props: CustomButtonProps): JSX.Element => {
   const { image, children, color, size, onClickEvent, isValid } = props;
-
+  const isDisabled = isValid === undefined ? false : !isValid;
   return (
-    <S.Button disabled={!isValid} onClick={onClickEvent} color={color} size={size}>
+    <S.Button disabled={isDisabled} onClick={onClickEvent} color={color} size={size}>
       {image ? (
         <>
           <S.ButtonImg />

--- a/client/src/container/TransactionModal/index.tsx
+++ b/client/src/container/TransactionModal/index.tsx
@@ -49,14 +49,14 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
     if (checkValidation(e.target.name, e.target.value)) {
       infoDispatch({ ...newTransaction, [e.target.name]: e.target.value });
       validation.add(e.target.name);
-      setValidation(new Set([...validation]));
+      setValidation(validation);
     } else {
       validation.delete(e.target.name);
-      setValidation(new Set([...validation]));
+      setValidation(validation);
     }
     if ((e.target.name === 'description' || e.target.name === 'amount') && e.target.value === '') {
       validation.delete(e.target.name);
-      setValidation(new Set([...validation]));
+      setValidation(validation);
     }
   };
 
@@ -80,7 +80,7 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
         checkEmpty(['', `${parsedText.amount}`, clipText, 'false']).map((addList) =>
           validation.add(addList),
         );
-        setValidation(new Set([...validation]));
+        setValidation(validation);
         setIsIncome(false);
       } else {
         const { year: thisYear } = DateUtils.parseDate(new Date());
@@ -99,7 +99,7 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
           clipText,
           `${parsedText.isDeposit}`,
         ]).map((addList) => validation.add(addList));
-        setValidation(new Set([...validation]));
+        setValidation(validation);
       }
     });
   }, []);

--- a/client/src/container/TransactionModal/index.tsx
+++ b/client/src/container/TransactionModal/index.tsx
@@ -16,7 +16,7 @@ import SMSParser from '@/libs/smsParser/parser';
 import DateUtils from '@/libs/dateUtils';
 import ModalInput from '@/components/transaction/ModalInput';
 import ModalHeader from '@/components/transaction/ModalHeader';
-import checkValidation from '@/libs/checkValidation';
+import { checkValidation, checkEmpty } from '@/libs/checkValidation';
 import * as S from './styles';
 import { TransactionModalProps } from './types';
 
@@ -66,7 +66,6 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
     toggleModal();
   }, [newTransaction]);
 
-
   const parseClipboardText = useCallback(() => {
     navigator.clipboard.readText().then((clipText) => {
       const parsedText = SMSParser.parse(clipText);
@@ -78,6 +77,10 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
           amount: `${parsedText.amount}`,
           description: clipText,
         });
+        checkEmpty(['', `${parsedText.amount}`, clipText, 'false']).map((addList) =>
+          validation.add(addList),
+        );
+        setValidation(new Set([...validation]));
         setIsIncome(false);
       } else {
         const { year: thisYear } = DateUtils.parseDate(new Date());
@@ -90,10 +93,16 @@ const TransactionModal = ({ show, toggleModal }: TransactionModalProps): JSX.Ele
           isIncome: `${parsedText.isDeposit}`,
         });
         setIsIncome(parsedText.isDeposit);
+        checkEmpty([
+          formattedDate,
+          `${parsedText.amount}`,
+          clipText,
+          `${parsedText.isDeposit}`,
+        ]).map((addList) => validation.add(addList));
+        setValidation(new Set([...validation]));
       }
     });
   }, []);
-
   return (
     <>
       {paymentList && categoryList && (

--- a/client/src/container/TransactionUpdateModal/index.tsx
+++ b/client/src/container/TransactionUpdateModal/index.tsx
@@ -11,7 +11,7 @@ import { UpdateTransactionRequest } from '@/commons/types/transaction';
 import ModalInput from '@/components/transaction/ModalInput';
 import CustomSelectInput from '@/components/common/forms/CustomSelectInput';
 import CustomButton from '@/components/common/buttons/CustomButton';
-import checkValidation from '@/libs/checkValidation';
+import { checkValidation } from '@/libs/checkValidation';
 import TransactionRequestDTO from '@/commons/dto/transaction-request';
 import { deleteTransactionThunk, updateTransactionThunk } from '@/modules/transaction';
 import * as S from './styles';

--- a/client/src/libs/checkOverlap.ts
+++ b/client/src/libs/checkOverlap.ts
@@ -1,7 +1,7 @@
 import CategoryDTO from '@/commons/dto/category';
 import PaymentDTO from '@/commons/dto/payment';
 
-const checkOverlap = (target: string, dataList: Array<CategoryDTO | PaymentDTO>) => {
+const checkOverlap = (target: string, dataList: Array<CategoryDTO | PaymentDTO>): boolean => {
   if (target === undefined || target === '') return false;
   return !dataList.some((e) => e.name.trim() === target.trim());
 };

--- a/client/src/libs/checkValidation.ts
+++ b/client/src/libs/checkValidation.ts
@@ -5,7 +5,7 @@ const checkValidation = (name: string, target: string): boolean => {
   return true;
 };
 
-const checkEmpty = (TransactionList: string[]) => {
+const checkEmpty = (TransactionList: string[]): string[] => {
   const keyList = ['tradeAt', 'amount', 'description', 'isIncome'];
   return keyList.filter((key, i) => {
     if (TransactionList[i] === '' || TransactionList[i] === '0') return false;

--- a/client/src/libs/checkValidation.ts
+++ b/client/src/libs/checkValidation.ts
@@ -5,4 +5,11 @@ const checkValidation = (name: string, target: string): boolean => {
   return true;
 };
 
-export default checkValidation;
+const checkEmpty = (TransactionList: string[]) => {
+  const keyList = ['tradeAt', 'amount', 'description', 'isIncome'];
+  return keyList.filter((key, i) => {
+    if (TransactionList[i] === '' || TransactionList[i] === '0') return false;
+    return true;
+  });
+};
+export { checkValidation, checkEmpty };


### PR DESCRIPTION
### Issue Number

Close #213


### 새로운 기능

1. 이전 유효성 검사는 파서 시 파서된 항목이 유효성 검사 set에 포함되지 않는 오류 발생.
=> 파서 후 남은 항목 선택 시에도 유효성 검사가 되어야 함.
![image](https://user-images.githubusercontent.com/68668924/102223281-d5e8a480-3f27-11eb-9017-0073046066a8.png)
![image](https://user-images.githubusercontent.com/68668924/102223287-d8e39500-3f27-11eb-9bd6-d4aeefe76af6.png)

### 수정 사항
1. 버튼이 클릭되지 않는 버그 수정
=> disabled가 입력되지 않는 경우 false로 처리가 되어 클릭되지 않던 오류 수정


### 작업 유형

- [x] 신규 기능 추가
- [X] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
