### PR TITLE
transaction scroll 오류 수정

### DIFF
--- a/client/src/container/TransactionList/index.tsx
+++ b/client/src/container/TransactionList/index.tsx
@@ -21,6 +21,7 @@ const TransactionListContainer = ({ editable }: TransactionListContainerProps): 
   );
 
   const maxLength = transaction.aggregationByDate.length / 5;
+
   const changeExtraTransaction = () => {
     const newrenderedTransaction = renderedTransaction.concat(
       transaction.transactionDetailsByDate.slice(5 * length.current, 5 * length.current + 5),
@@ -64,7 +65,7 @@ const TransactionListContainer = ({ editable }: TransactionListContainerProps): 
     <>
       {transaction.transactionDetailsByDate.length !== 0 ? (
         renderedTransaction.map(([date, transactionDetails]) => (
-          <S.DateContainer key={`transaction_box_${date}`} ref={target}>
+          <S.DateContainer key={`transaction_box_${date}${Math.random()}`} ref={target}>
             <S.DateLabel>{date}일</S.DateLabel>
             {transactionDetails.map((transactionDetail) => (
               <S.TransactionListItemWrapper key={`transaction_Wrap${transactionDetail.tid}`}>
@@ -87,4 +88,4 @@ const TransactionListContainer = ({ editable }: TransactionListContainerProps): 
   );
 };
 
-export default TransactionListContainer;
+export default React.memo(TransactionListContainer);


### PR DESCRIPTION
### Issue Number

Close #234


### 변경사항

거래 추가 또는 수정시 스크롤 버그 해결
수정사항이 발생하여 리랜더링시 기존의 key 와 동일하여 ref를 새로 주입하지 않아서 임시방편으로 `math.random()` 으로 키가 중복되지 않게 해결하였습니다. 

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

@boostcamp-2020/accountbook_mentor
